### PR TITLE
Release macOS Intel builds

### DIFF
--- a/.github/workflows/macos-signed-build.yml
+++ b/.github/workflows/macos-signed-build.yml
@@ -23,6 +23,9 @@ jobs:
           - platform: macos-15
             target: aarch64-apple-darwin
             artifact_suffix: macos-aarch64
+          - platform: macos-15-intel
+            target: x86_64-apple-darwin
+            artifact_suffix: macos-x86_64
 
     runs-on: ${{ matrix.platform }}
     steps:
@@ -47,7 +50,7 @@ jobs:
       - name: Set up Rust
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: aarch64-apple-darwin
+          targets: ${{ matrix.target }}
 
       - name: Rust cache
         uses: swatinem/rust-cache@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -202,6 +202,9 @@ jobs:
           - platform: macos-15
             target: aarch64-apple-darwin
             artifact_suffix: macos-aarch64
+          - platform: macos-15-intel
+            target: x86_64-apple-darwin
+            artifact_suffix: macos-x86_64
           - platform: ubuntu-24.04
             target: x86_64-unknown-linux-gnu
             artifact_suffix: linux-x86_64
@@ -230,7 +233,7 @@ jobs:
             patchelf
 
       - name: Set up protoc (macOS)
-        if: matrix.artifact_suffix == 'macos-aarch64'
+        if: contains(matrix.target, 'apple-darwin')
         run: brew install protobuf
 
       - name: Set up protoc (Windows)
@@ -427,9 +430,15 @@ jobs:
       matrix:
         include:
           - platform: macos-15
+            target: aarch64-apple-darwin
             args: --target aarch64-apple-darwin --config src-tauri/tauri.macos.conf.json -- --bin xero-desktop
             artifact_suffix: macos-aarch64
             platform_key: darwin-aarch64
+          - platform: macos-15-intel
+            target: x86_64-apple-darwin
+            args: --target x86_64-apple-darwin --config src-tauri/tauri.macos.conf.json -- --bin xero-desktop
+            artifact_suffix: macos-x86_64
+            platform_key: darwin-x86_64
           - platform: windows-2025-vs2026
             args: --bundles nsis -- --bin xero-desktop
             artifact_suffix: windows-x86_64
@@ -489,7 +498,7 @@ jobs:
         if: contains(matrix.platform_key, 'darwin')
         uses: dtolnay/rust-toolchain@stable
         with:
-          targets: aarch64-apple-darwin
+          targets: ${{ matrix.target }}
 
       - name: Set up Rust
         if: ${{ !contains(matrix.platform_key, 'darwin') }}
@@ -523,8 +532,8 @@ jobs:
         run: |
           set -euo pipefail
           case "${{ matrix.platform_key }}" in
-            darwin-aarch64)
-              cargo build --release --package xero-desktop-sidecar --target aarch64-apple-darwin
+            darwin-*)
+              cargo build --release --package xero-desktop-sidecar --target ${{ matrix.target }}
               ;;
             *)
               cargo build --release --package xero-desktop-sidecar

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-project",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "private": true,
   "scripts": {
     "dev": "vite --host 0.0.0.0 --port 3000",

--- a/client/src-tauri/Cargo.lock
+++ b/client/src-tauri/Cargo.lock
@@ -11839,7 +11839,7 @@ dependencies = [
 
 [[package]]
 name = "xero-cli"
-version = "0.1.33"
+version = "0.1.34"
 dependencies = [
  "crossterm",
  "flate2",
@@ -11860,7 +11860,7 @@ dependencies = [
 
 [[package]]
 name = "xero-desktop"
-version = "0.1.33"
+version = "0.1.34"
 dependencies = [
  "arc-swap",
  "arrow-array",

--- a/client/src-tauri/Cargo.toml
+++ b/client/src-tauri/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 
 [package]
 name = "xero-desktop"
-version = "0.1.33"
+version = "0.1.34"
 edition = "2021"
 default-run = "xero-desktop"
 description = "Xero desktop host"

--- a/client/src-tauri/crates/xero-cli/Cargo.toml
+++ b/client/src-tauri/crates/xero-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xero-cli"
-version = "0.1.33"
+version = "0.1.34"
 edition = "2021"
 description = "Headless Xero CLI backed by xero-agent-core"
 

--- a/client/src-tauri/tauri.conf.json
+++ b/client/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Xero",
   "mainBinaryName": "xero-desktop",
-  "version": "0.1.33",
+  "version": "0.1.34",
   "identifier": "com.hyperpush.xero",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Summary
- add macOS Intel release matrix entries for the desktop client and TUI
- bump desktop client and TUI versions to 0.1.34

## Verification
- ruby YAML parse for release workflows
- git diff --check
- XERO_SKIP_COOKIE_IMPORTER=1 XERO_SKIP_DICTATION_SHIM=1 XERO_SKIP_SIDECAR_FETCH=1 XERO_SKIP_DESKTOP_SIDECAR=1 XERO_SKIP_IOS_HELPER=1 cargo check --package xero-desktop --bin xero --bin xero-desktop
- pnpm --dir client build
- pnpm release:push 0.1.34 --dry-run

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/hyperpush-org/codesmith/xero/pr/29"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782681005&installation_id=136409793&pr_number=29&repository=hyperpush-org%2Fxero&return_to=https%3A%2F%2Fgithub.com%2Fhyperpush-org%2Fxero%2Fpull%2F29&signature=458b8ef41b9bce0f45f207ee9cfc1dcb491ad876db58eb17befbf6d8ba2dc8ce"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->