### PR TITLE
Release 0.1.35

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,7 @@ jobs:
             libegl-dev \
             libgbm-dev \
             libpipewire-0.3-dev \
+            libprotobuf-dev \
             libssl-dev \
             pkg-config \
             librsvg2-dev \
@@ -224,6 +225,7 @@ jobs:
             libxcb-randr0-dev \
             libxcb-shape0-dev \
             libxcb-xfixes0-dev \
+            libprotobuf-dev \
             protobuf-compiler \
             pkg-config
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -226,6 +226,7 @@ jobs:
             libegl-dev \
             libgbm-dev \
             libpipewire-0.3-dev \
+            libprotobuf-dev \
             libssl-dev \
             pkg-config \
             librsvg2-dev \
@@ -480,6 +481,7 @@ jobs:
             libegl-dev \
             libgbm-dev \
             libpipewire-0.3-dev \
+            libprotobuf-dev \
             libssl-dev \
             pkg-config \
             librsvg2-dev \

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-project",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "private": true,
   "scripts": {
     "dev": "vite --host 0.0.0.0 --port 3000",

--- a/client/src-tauri/Cargo.lock
+++ b/client/src-tauri/Cargo.lock
@@ -11839,7 +11839,7 @@ dependencies = [
 
 [[package]]
 name = "xero-cli"
-version = "0.1.34"
+version = "0.1.35"
 dependencies = [
  "crossterm",
  "flate2",
@@ -11860,7 +11860,7 @@ dependencies = [
 
 [[package]]
 name = "xero-desktop"
-version = "0.1.34"
+version = "0.1.35"
 dependencies = [
  "arc-swap",
  "arrow-array",

--- a/client/src-tauri/Cargo.toml
+++ b/client/src-tauri/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 
 [package]
 name = "xero-desktop"
-version = "0.1.34"
+version = "0.1.35"
 edition = "2021"
 default-run = "xero-desktop"
 description = "Xero desktop host"

--- a/client/src-tauri/crates/xero-cli/Cargo.toml
+++ b/client/src-tauri/crates/xero-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xero-cli"
-version = "0.1.34"
+version = "0.1.35"
 edition = "2021"
 description = "Headless Xero CLI backed by xero-agent-core"
 

--- a/client/src-tauri/tauri.conf.json
+++ b/client/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Xero",
   "mainBinaryName": "xero-desktop",
-  "version": "0.1.34",
+  "version": "0.1.35",
   "identifier": "com.hyperpush.xero",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Summary
- Add explicit protobuf development headers to Linux CI/release jobs so Lance can find well-known protobuf imports.
- Bump desktop client and TUI versions to 0.1.35.

## Verification
- YAML parse for workflow files
- actionlint for workflow files
- node --check scripts/push-release.mjs
- git diff --check
- cargo metadata --locked --no-deps --format-version 1
- scripts/push-release.mjs 0.1.35 --dry-run

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/hyperpush-org/codesmith/xero/pr/30"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782682203&installation_id=136409793&pr_number=30&repository=hyperpush-org%2Fxero&return_to=https%3A%2F%2Fgithub.com%2Fhyperpush-org%2Fxero%2Fpull%2F30&signature=9585756422f1993eaf83c02105d0514bd51d6c9ee827a3ae097352937226d97b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->