### PR TITLE
Release 0.1.36

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -460,16 +460,32 @@ jobs:
           path: client/dist
 
       - name: Set up pnpm
+        if: matrix.platform_key != 'windows-x86_64'
         uses: pnpm/action-setup@v6
         with:
           version: 10.28.1
 
       - name: Set up Node
+        if: matrix.platform_key != 'windows-x86_64'
         uses: actions/setup-node@v6
         with:
           node-version: 24
           cache: pnpm
           cache-dependency-path: client/pnpm-lock.yaml
+
+      - name: Set up Node (Windows)
+        if: matrix.platform_key == 'windows-x86_64'
+        uses: actions/setup-node@v6
+        with:
+          node-version: 24
+
+      - name: Set up pnpm (Windows)
+        if: matrix.platform_key == 'windows-x86_64'
+        shell: pwsh
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.28.1 --activate
+          pnpm --version
 
       - name: Install Linux Tauri dependencies
         if: matrix.platform_key == 'linux-x86_64'

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-project",
-  "version": "0.1.35",
+  "version": "0.1.36",
   "private": true,
   "scripts": {
     "dev": "vite --host 0.0.0.0 --port 3000",

--- a/client/src-tauri/Cargo.lock
+++ b/client/src-tauri/Cargo.lock
@@ -11839,7 +11839,7 @@ dependencies = [
 
 [[package]]
 name = "xero-cli"
-version = "0.1.35"
+version = "0.1.36"
 dependencies = [
  "crossterm",
  "flate2",
@@ -11860,7 +11860,7 @@ dependencies = [
 
 [[package]]
 name = "xero-desktop"
-version = "0.1.35"
+version = "0.1.36"
 dependencies = [
  "arc-swap",
  "arrow-array",

--- a/client/src-tauri/Cargo.toml
+++ b/client/src-tauri/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 
 [package]
 name = "xero-desktop"
-version = "0.1.35"
+version = "0.1.36"
 edition = "2021"
 default-run = "xero-desktop"
 description = "Xero desktop host"

--- a/client/src-tauri/crates/xero-cli/Cargo.toml
+++ b/client/src-tauri/crates/xero-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xero-cli"
-version = "0.1.35"
+version = "0.1.36"
 edition = "2021"
 description = "Headless Xero CLI backed by xero-agent-core"
 

--- a/client/src-tauri/tauri.conf.json
+++ b/client/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Xero",
   "mainBinaryName": "xero-desktop",
-  "version": "0.1.35",
+  "version": "0.1.36",
   "identifier": "com.hyperpush.xero",
   "build": {
     "beforeDevCommand": "pnpm dev",


### PR DESCRIPTION
## Summary
- Avoid pnpm/action-setup on Windows Tauri release builds; use setup-node + Corepack instead.
- Bump desktop client and TUI versions to 0.1.36.

## Verification
- YAML parse for workflow files
- actionlint for workflow files
- node --check scripts/push-release.mjs
- git diff --check
- cargo metadata --locked --no-deps --format-version 1
- scripts/push-release.mjs 0.1.36 --dry-run

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/hyperpush-org/codesmith/xero/pr/31"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782682710&installation_id=136409793&pr_number=31&repository=hyperpush-org%2Fxero&return_to=https%3A%2F%2Fgithub.com%2Fhyperpush-org%2Fxero%2Fpull%2F31&signature=a2d6a44dde4fedc905d18ca3da7eab89009b6a900c795a70f5bef9b5526841a4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->