### PR TITLE
Release 0.1.38

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -109,7 +109,7 @@ jobs:
         uses: erlef/setup-beam@v1
         with:
           otp-version: 26.2.1
-          elixir-version: 1.15.7
+          elixir-version: 1.16.3
 
       - name: Cache Mix
         uses: actions/cache@v5

--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-project",
-  "version": "0.1.37",
+  "version": "0.1.38",
   "private": true,
   "scripts": {
     "dev": "vite --host 0.0.0.0 --port 3000",

--- a/client/src-tauri/Cargo.lock
+++ b/client/src-tauri/Cargo.lock
@@ -11839,7 +11839,7 @@ dependencies = [
 
 [[package]]
 name = "xero-cli"
-version = "0.1.37"
+version = "0.1.38"
 dependencies = [
  "crossterm",
  "flate2",
@@ -11860,7 +11860,7 @@ dependencies = [
 
 [[package]]
 name = "xero-desktop"
-version = "0.1.37"
+version = "0.1.38"
 dependencies = [
  "arc-swap",
  "arrow-array",

--- a/client/src-tauri/Cargo.toml
+++ b/client/src-tauri/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 
 [package]
 name = "xero-desktop"
-version = "0.1.37"
+version = "0.1.38"
 edition = "2021"
 default-run = "xero-desktop"
 description = "Xero desktop host"

--- a/client/src-tauri/build.rs
+++ b/client/src-tauri/build.rs
@@ -82,9 +82,6 @@ fn compile_dictation_shim() {
     println!("cargo:rustc-link-lib=framework=Security");
 
     if std::env::var_os("XERO_SKIP_DICTATION_SHIM").is_some() {
-        println!(
-            "cargo:warning=XERO_SKIP_DICTATION_SHIM is set; dictation status will report the native shim unavailable."
-        );
         return;
     }
 
@@ -200,9 +197,6 @@ fn compile_ios_helper() {
     println!("cargo:rerun-if-env-changed=XERO_SKIP_IOS_HELPER");
 
     if std::env::var_os("XERO_SKIP_IOS_HELPER").is_some() {
-        println!(
-            "cargo:warning=XERO_SKIP_IOS_HELPER is set; iOS helper binary will not be compiled."
-        );
         return;
     }
 

--- a/client/src-tauri/crates/xero-cli/Cargo.toml
+++ b/client/src-tauri/crates/xero-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xero-cli"
-version = "0.1.37"
+version = "0.1.38"
 edition = "2021"
 description = "Headless Xero CLI backed by xero-agent-core"
 

--- a/client/src-tauri/crates/xero-desktop-sidecar/src/main.rs
+++ b/client/src-tauri/crates/xero-desktop-sidecar/src/main.rs
@@ -2,8 +2,8 @@ use std::{
     collections::BTreeMap,
     fs,
     io::{self, BufRead, Cursor, Write},
-    path::{Path, PathBuf},
-    process::{self, Command},
+    path::Path,
+    process,
     sync::{
         atomic::{AtomicBool, AtomicI64, AtomicU64, Ordering},
         Arc, Mutex, OnceLock,
@@ -11,18 +11,24 @@ use std::{
     time::{Duration, Instant},
 };
 
+#[cfg(target_os = "macos")]
+use std::path::PathBuf;
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+use std::process::Command;
+
 use base64::Engine as _;
 use image::{ImageFormat, RgbaImage};
 use serde::Deserialize;
 use serde_json::json;
 use time::format_description::well_known::Rfc3339;
+#[cfg(any(test, target_os = "macos", target_os = "windows"))]
+use webrtc::media::Sample;
 use webrtc::{
     api::{
         media_engine::{MediaEngine, MIME_TYPE_H264},
         APIBuilder,
     },
     ice_transport::{ice_candidate::RTCIceCandidateInit, ice_server::RTCIceServer},
-    media::Sample,
     peer_connection::{
         configuration::RTCConfiguration, sdp::session_description::RTCSessionDescription,
         RTCPeerConnection,
@@ -38,10 +44,11 @@ use webrtc::{
 use xcap::{Monitor, Window};
 #[cfg(target_os = "windows")]
 use xero_desktop_control_ipc::DesktopSidecarNotificationEntry;
+#[cfg(any(target_os = "macos", target_os = "windows"))]
+use xero_desktop_control_ipc::DesktopSidecarOcrTextBlock;
 use xero_desktop_control_ipc::{
-    validate_sidecar_handshake, validate_sidecar_request, DesktopSidecarAccessibilityElement,
+    validate_sidecar_handshake, validate_sidecar_request,
     DesktopSidecarAccessibilitySnapshotPayload, DesktopSidecarAccessibilitySnapshotRequest,
-    DesktopSidecarAccessibilitySnapshotRow, DesktopSidecarAccessibilitySnapshotTarget,
     DesktopSidecarApp, DesktopSidecarAppInventoryEntry, DesktopSidecarAppInventoryPayload,
     DesktopSidecarAppListPayload, DesktopSidecarCapabilities, DesktopSidecarClipboardFilesPayload,
     DesktopSidecarClipboardHtmlPayload, DesktopSidecarClipboardImagePayload,
@@ -51,14 +58,19 @@ use xero_desktop_control_ipc::{
     DesktopSidecarDisplayListPayload, DesktopSidecarElementAtPointPayload, DesktopSidecarErrorBody,
     DesktopSidecarForegroundStatePayload, DesktopSidecarHandshake, DesktopSidecarLease,
     DesktopSidecarNotificationSnapshotPayload, DesktopSidecarOcrSnapshotPayload,
-    DesktopSidecarOcrSnapshotRequest, DesktopSidecarOcrTextBlock, DesktopSidecarOperation,
-    DesktopSidecarPermissionGrant, DesktopSidecarPermissionStatus,
-    DesktopSidecarPermissionsPayload, DesktopSidecarPointRequest, DesktopSidecarRequest,
-    DesktopSidecarResponse, DesktopSidecarScreenshotPayload, DesktopSidecarScreenshotRequest,
-    DesktopSidecarSessionDescription, DesktopSidecarStreamCapabilitiesPayload,
-    DesktopSidecarStreamMetrics, DesktopSidecarStreamPayload, DesktopSidecarStreamQuality,
-    DesktopSidecarStreamRequest, DesktopSidecarStreamStatus, DesktopSidecarStreamTransport,
-    DesktopSidecarWindow, DesktopSidecarWindowListPayload,
+    DesktopSidecarOcrSnapshotRequest, DesktopSidecarOperation, DesktopSidecarPermissionGrant,
+    DesktopSidecarPermissionStatus, DesktopSidecarPermissionsPayload, DesktopSidecarPointRequest,
+    DesktopSidecarRequest, DesktopSidecarResponse, DesktopSidecarScreenshotPayload,
+    DesktopSidecarScreenshotRequest, DesktopSidecarSessionDescription,
+    DesktopSidecarStreamCapabilitiesPayload, DesktopSidecarStreamMetrics,
+    DesktopSidecarStreamPayload, DesktopSidecarStreamQuality, DesktopSidecarStreamRequest,
+    DesktopSidecarStreamStatus, DesktopSidecarStreamTransport, DesktopSidecarWindow,
+    DesktopSidecarWindowListPayload,
+};
+#[cfg(target_os = "macos")]
+use xero_desktop_control_ipc::{
+    DesktopSidecarAccessibilityElement, DesktopSidecarAccessibilitySnapshotRow,
+    DesktopSidecarAccessibilitySnapshotTarget,
 };
 
 const WEBRTC_MAX_WIDTH: u32 = 1920;
@@ -8440,6 +8452,7 @@ mod cross_platform_input {
             "volumeup" | "volume_up" | "audio_volume_up" => Ok(Key::VolumeUp),
             "volumedown" | "volume_down" | "audio_volume_down" => Ok(Key::VolumeDown),
             "volumemute" | "volume_mute" | "mute" | "audio_mute" => Ok(Key::VolumeMute),
+            #[cfg(all(unix, not(target_os = "macos")))]
             "micmute" | "mic_mute" => Ok(Key::MicMute),
             "mediaplaypause" | "media_play_pause" | "playpause" | "play_pause" => {
                 Ok(Key::MediaPlayPause)
@@ -8450,12 +8463,6 @@ mod cross_platform_input {
             "mediaprevious" | "media_previous" | "media_prev" | "media_prev_track"
             | "previous_track" | "prev_track" => Ok(Key::MediaPrevTrack),
             "mediastop" | "media_stop" => Ok(Key::MediaStop),
-            "mediafast" | "media_fast" | "media_fast_forward" | "fast_forward" => {
-                Ok(Key::MediaFast)
-            }
-            "mediarewind" | "media_rewind" | "rewind" => Ok(Key::MediaRewind),
-            "brightnessup" | "brightness_up" => Ok(Key::BrightnessUp),
-            "brightnessdown" | "brightness_down" => Ok(Key::BrightnessDown),
             "shift" => Ok(Key::Shift),
             "ctrl" | "control" => Ok(Key::Control),
             "alt" | "option" => Ok(Key::Alt),
@@ -8492,6 +8499,36 @@ mod cross_platform_input {
             assert_eq!(key_for("Backspace").expect("backspace"), Key::Backspace);
             assert_eq!(key_for("Delete").expect("delete"), Key::Delete);
             assert_eq!(key_for("v").expect("v"), Key::Unicode('v'));
+        }
+
+        #[test]
+        fn key_mapper_rejects_macos_only_keys() {
+            for key in [
+                "media_fast_forward",
+                "media_rewind",
+                "brightness_up",
+                "brightness_down",
+            ] {
+                assert_eq!(
+                    key_for(key).expect_err("macOS-only key").code,
+                    "desktop_key_unsupported"
+                );
+            }
+        }
+
+        #[cfg(target_os = "windows")]
+        #[test]
+        fn key_mapper_rejects_linux_only_keys_on_windows() {
+            assert_eq!(
+                key_for("mic_mute").expect_err("Linux-only key").code,
+                "desktop_key_unsupported"
+            );
+        }
+
+        #[cfg(all(unix, not(target_os = "macos")))]
+        #[test]
+        fn key_mapper_accepts_linux_mic_mute_key() {
+            assert_eq!(key_for("mic_mute").expect("mic mute"), Key::MicMute);
         }
 
         #[test]

--- a/client/src-tauri/src/runtime/autonomous_tool_runtime/macos_automation.rs
+++ b/client/src-tauri/src/runtime/autonomous_tool_runtime/macos_automation.rs
@@ -259,6 +259,7 @@ fn macos_action_label(action: AutonomousMacosAutomationAction) -> &'static str {
     }
 }
 
+#[cfg(any(target_os = "macos", test))]
 fn resolve_monitor_index(
     monitor_ids: &[Option<u32>],
     primary_flags: &[bool],
@@ -291,6 +292,7 @@ fn resolve_monitor_index(
         .or(Some(0))
 }
 
+#[cfg(any(target_os = "macos", test))]
 fn monitor_not_found_message(requested_monitor: u32, monitor_ids: &[Option<u32>]) -> String {
     let available = monitor_ids
         .iter()

--- a/client/src-tauri/tauri.conf.json
+++ b/client/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Xero",
   "mainBinaryName": "xero-desktop",
-  "version": "0.1.37",
+  "version": "0.1.38",
   "identifier": "com.hyperpush.xero",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/server/mix.exs
+++ b/server/mix.exs
@@ -5,7 +5,7 @@ defmodule Xero.MixProject do
     [
       app: :xero,
       version: "0.1.0",
-      elixir: "~> 1.15",
+      elixir: "~> 1.16",
       elixirc_paths: elixirc_paths(Mix.env()),
       start_permanent: Mix.env() == :prod,
       aliases: aliases(),


### PR DESCRIPTION
## Summary
- Bump desktop client and TUI from 0.1.37 to 0.1.38.
- Fix release/CI failures found in the canceled 0.1.37 runs: cfg-gate platform-specific sidecar imports/keys, quiet explicit Cargo build skips, and align server CI with Elixir 1.16.

## Validation
- git diff --check
- TypeScript/JS: client eslint --max-warnings=0, tsc --noEmit, vitest (1111 passed, 2 skipped), client build; landing eslint --max-warnings=0, tsc --noEmit, build; cloud biome check --error-on-warnings, tsc --noEmit, vitest (233 passed), build; packages/ui typecheck + vitest (72 passed); marketing main/solana eslint --max-warnings=0 + tsc --noEmit.
- Elixir: mix deps.get, mix format --check-formatted, MIX_ENV=test mix compile --warnings-as-errors, MIX_ENV=test mix test --warnings-as-errors (29 tests, 0 failures).
- Rust: cargo fmt --check, cargo check --workspace with -D warnings, cargo clippy --workspace --all-targets -D warnings, cargo test --workspace with -D warnings, release-style TUI cargo build with release workflow skip envs.

## Notes
- v0.1.37 was already tagged; this replacement release uses v0.1.38.
- PR CI is required before merging so Linux/Windows runner coverage validates the sidecar fixes.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/hyperpush-org/codesmith/xero/pr/39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782809036&installation_id=136409793&pr_number=39&repository=hyperpush-org%2Fxero&return_to=https%3A%2F%2Fgithub.com%2Fhyperpush-org%2Fxero%2Fpull%2F39&signature=0dea34961ca3d42314121962331182e013703f38ca45704326e1839d05e738f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->