### PR TITLE
Release v0.1.40

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "my-project",
-  "version": "0.1.39",
+  "version": "0.1.40",
   "private": true,
   "scripts": {
     "dev": "vite --host 0.0.0.0 --port 3000",

--- a/client/src-tauri/Cargo.lock
+++ b/client/src-tauri/Cargo.lock
@@ -11839,7 +11839,7 @@ dependencies = [
 
 [[package]]
 name = "xero-cli"
-version = "0.1.39"
+version = "0.1.40"
 dependencies = [
  "crossterm",
  "flate2",
@@ -11860,7 +11860,7 @@ dependencies = [
 
 [[package]]
 name = "xero-desktop"
-version = "0.1.39"
+version = "0.1.40"
 dependencies = [
  "arc-swap",
  "arrow-array",

--- a/client/src-tauri/Cargo.toml
+++ b/client/src-tauri/Cargo.toml
@@ -12,7 +12,7 @@ resolver = "2"
 
 [package]
 name = "xero-desktop"
-version = "0.1.39"
+version = "0.1.40"
 edition = "2021"
 default-run = "xero-desktop"
 description = "Xero desktop host"

--- a/client/src-tauri/crates/xero-cli/Cargo.toml
+++ b/client/src-tauri/crates/xero-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "xero-cli"
-version = "0.1.39"
+version = "0.1.40"
 edition = "2021"
 description = "Headless Xero CLI backed by xero-agent-core"
 

--- a/client/src-tauri/crates/xero-remote-bridge/src/lib.rs
+++ b/client/src-tauri/crates/xero-remote-bridge/src/lib.rs
@@ -875,7 +875,7 @@ impl Default for DesktopBridgeLoopOptions {
     fn default() -> Self {
         Self {
             heartbeat_interval: Duration::from_secs(30),
-            read_timeout: Duration::from_millis(500),
+            read_timeout: Duration::from_millis(50),
         }
     }
 }
@@ -1964,6 +1964,11 @@ fn outbound_priority_for_payload(payload: &JsonValue) -> OutboundPriority {
         .get("schema")
         .and_then(JsonValue::as_str)
         .unwrap_or_default();
+    if schema == "xero.computer_use_manual_control_input.v1"
+        && manual_pointer_outcome_is_best_effort(&envelope.payload)
+    {
+        return OutboundPriority::CoalescedBestEffort;
+    }
     if schema.starts_with("xero.computer_use_manual_control_")
         || schema == "xero.computer_use_stream_offer.v1"
         || schema == "xero.computer_use_stream_answer.v1"
@@ -1979,6 +1984,24 @@ fn outbound_priority_for_payload(payload: &JsonValue) -> OutboundPriority {
         return OutboundPriority::CoalescedBestEffort;
     }
     OutboundPriority::ReliableIdempotent
+}
+
+fn manual_pointer_outcome_is_best_effort(payload: &JsonValue) -> bool {
+    if payload.get("ok").and_then(JsonValue::as_bool) == Some(false) {
+        return false;
+    }
+    matches!(
+        manual_control_input_action(payload),
+        Some("mouse_move" | "mouse_drag_move")
+    )
+}
+
+fn manual_control_input_action(payload: &JsonValue) -> Option<&str> {
+    payload
+        .get("payload")
+        .and_then(JsonValue::as_object)
+        .and_then(|payload| payload.get("action"))
+        .and_then(JsonValue::as_str)
 }
 
 fn outbound_queue_limit(priority: OutboundPriority) -> usize {
@@ -2017,6 +2040,18 @@ fn outbound_frame_coalesce_key(
         .get("schema")
         .and_then(JsonValue::as_str)
         .unwrap_or_default();
+    if schema == "xero.computer_use_manual_control_input.v1" {
+        let manual_control_id = envelope
+            .payload
+            .get("manualControlId")
+            .or_else(|| envelope.payload.get("manual_control_id"))
+            .and_then(JsonValue::as_str)
+            .unwrap_or_default();
+        let action = manual_control_input_action(&envelope.payload).unwrap_or_default();
+        return Some(format!(
+            "{session_id}:{schema}:{manual_control_id}:{action}"
+        ));
+    }
     let stream_id = envelope
         .payload
         .get("streamId")
@@ -2743,6 +2778,52 @@ mod tests {
             "xero.computer_use_stream_status.v1"
         );
         assert_eq!(envelope.payload["status"], "live");
+    }
+
+    #[test]
+    fn bridge_outbound_queue_coalesces_successful_pointer_outcomes() {
+        let temp = tempfile_path("bridge-pointer-outcome-coalesced");
+        let identity_store = FileIdentityStore::new(temp.join("identity.json"));
+        identity_store.save(&test_identity()).expect("identity");
+        let bridge = RemoteBridge::new(BridgeConfig::local_default(), identity_store);
+
+        bridge
+            .forward(
+                "session-1",
+                json!({
+                    "schema": "xero.computer_use_manual_control_input.v1",
+                    "ok": true,
+                    "manualControlId": "manual-1",
+                    "payload": {
+                        "action": "mouse_drag_move",
+                        "x": 10,
+                    },
+                }),
+            )
+            .expect("first pointer outcome");
+        bridge
+            .forward(
+                "session-1",
+                json!({
+                    "schema": "xero.computer_use_manual_control_input.v1",
+                    "ok": true,
+                    "manualControlId": "manual-1",
+                    "payload": {
+                        "action": "mouse_drag_move",
+                        "x": 20,
+                    },
+                }),
+            )
+            .expect("second pointer outcome");
+
+        let telemetry = bridge.telemetry_snapshot().expect("telemetry");
+        assert_eq!(telemetry.outbound_queue_depth, 1);
+        assert_eq!(telemetry.coalesced_outbound_count, 1);
+
+        let mut queue = bridge.outbound_queue.lock().expect("outbound lock");
+        let queued = queue.pop_front().expect("queued latest").frame;
+        let envelope = queued_session_frame_envelope(&queued);
+        assert_eq!(envelope.payload["payload"]["x"], 20);
     }
 
     #[test]

--- a/client/src-tauri/src/commands/remote_bridge.rs
+++ b/client/src-tauri/src/commands/remote_bridge.rs
@@ -4,7 +4,10 @@ use std::{
     path::Path,
     sync::{
         atomic::{AtomicBool, Ordering},
-        mpsc::TryRecvError as InboundTryRecvError,
+        mpsc::{
+            Receiver as InboundReceiver, RecvTimeoutError as InboundRecvTimeoutError,
+            TryRecvError as InboundTryRecvError,
+        },
         Arc, Mutex, OnceLock,
     },
     thread,
@@ -92,6 +95,7 @@ const STREAM_FALLBACK_FRAME_MAX_BYTES: usize = 5 * 1024 * 1024;
 const STREAM_FALLBACK_JPEG_QUALITY: u8 = 74;
 const COMMAND_OUTCOME_SCHEMA: &str = "xero.remote_command_outcome.v1";
 const MAX_DEDUPE_COMMAND_IDS: usize = 2048;
+const INBOUND_COMMAND_WAIT_TIMEOUT: Duration = Duration::from_millis(100);
 
 type AppRemoteBridge = RemoteBridge<FileIdentityStore>;
 
@@ -565,19 +569,24 @@ impl RemoteBridgeRuntimeState {
         let app = app.clone();
         let state = state.clone();
         let handle = thread::spawn(move || {
+            let mut pending = VecDeque::new();
             while !shutdown.load(Ordering::Relaxed) {
-                match inbound.try_recv() {
-                    Ok(command) => {
-                        if let Err(error) =
-                            handle_inbound_command(&app, &state, Arc::clone(&bridge), command)
-                        {
-                            eprintln!("[remote-bridge] inbound command failed: {error}");
-                        }
-                    }
-                    Err(InboundTryRecvError::Empty) => {
-                        thread::sleep(Duration::from_millis(100));
-                    }
-                    Err(InboundTryRecvError::Disconnected) => break,
+                let command = match pending.pop_front() {
+                    Some(command) => Some(command),
+                    None => match inbound.recv_timeout(INBOUND_COMMAND_WAIT_TIMEOUT) {
+                        Ok(command) => Some(command),
+                        Err(InboundRecvTimeoutError::Timeout) => None,
+                        Err(InboundRecvTimeoutError::Disconnected) => break,
+                    },
+                };
+                let Some(command) = command else {
+                    continue;
+                };
+                let command = coalesce_inbound_pointer_command(command, &inbound, &mut pending);
+                if let Err(error) =
+                    handle_inbound_command(&app, &state, Arc::clone(&bridge), command)
+                {
+                    eprintln!("[remote-bridge] inbound command failed: {error}");
                 }
             }
         });
@@ -592,6 +601,47 @@ impl RemoteBridgeRuntimeState {
             }
         }
     }
+}
+
+fn coalesce_inbound_pointer_command(
+    command: InboundCommand,
+    inbound: &InboundReceiver<InboundCommand>,
+    pending: &mut VecDeque<InboundCommand>,
+) -> InboundCommand {
+    let Some(coalesce_key) = inbound_pointer_coalesce_key(&command) else {
+        return command;
+    };
+    let mut latest = command;
+    loop {
+        match inbound.try_recv() {
+            Ok(next) if inbound_pointer_coalesce_key(&next).as_deref() == Some(&coalesce_key) => {
+                latest = next;
+            }
+            Ok(next) => {
+                pending.push_back(next);
+                break;
+            }
+            Err(InboundTryRecvError::Empty) | Err(InboundTryRecvError::Disconnected) => break,
+        }
+    }
+    latest
+}
+
+fn inbound_pointer_coalesce_key(command: &InboundCommand) -> Option<String> {
+    if command.kind != InboundCommandKind::ComputerUseManualControlInput {
+        return None;
+    }
+    let action = payload_string(&command.payload, &["action"])?;
+    if action != "mouse_move" && action != "mouse_drag_move" {
+        return None;
+    }
+    Some(format!(
+        "{}:{}:{}",
+        command.session_id.as_deref().unwrap_or_default(),
+        payload_string(&command.payload, &["manualControlId", "manual_control_id"])
+            .unwrap_or_default(),
+        action,
+    ))
 }
 
 fn set_runtime_event_forwarder(bridge: Arc<AppRemoteBridge>) {
@@ -4743,6 +4793,34 @@ mod tests {
 
         command.kind = InboundCommandKind::ListSessions;
         assert!(!command_is_duplicate(&command));
+    }
+
+    #[test]
+    fn inbound_pointer_coalescing_keeps_latest_contiguous_move() {
+        let (sender, receiver) = std::sync::mpsc::sync_channel(8);
+        let first = inbound_command(
+            InboundCommandKind::ComputerUseManualControlInput,
+            json!({"manualControlId": "manual-1", "action": "mouse_move", "x": 10}),
+        );
+        sender
+            .send(inbound_command(
+                InboundCommandKind::ComputerUseManualControlInput,
+                json!({"manualControlId": "manual-1", "action": "mouse_move", "x": 20}),
+            ))
+            .expect("second move");
+        sender
+            .send(inbound_command(
+                InboundCommandKind::ComputerUseManualControlInput,
+                json!({"manualControlId": "manual-1", "action": "type_text", "text": "hi"}),
+            ))
+            .expect("non-pointer input");
+        let mut pending = VecDeque::new();
+
+        let coalesced = coalesce_inbound_pointer_command(first, &receiver, &mut pending);
+
+        assert_eq!(coalesced.payload["x"], 20);
+        assert_eq!(pending.len(), 1);
+        assert_eq!(pending[0].payload["action"], "type_text");
     }
 
     #[test]

--- a/client/src-tauri/tauri.conf.json
+++ b/client/src-tauri/tauri.conf.json
@@ -2,7 +2,7 @@
   "$schema": "../node_modules/@tauri-apps/cli/config.schema.json",
   "productName": "Xero",
   "mainBinaryName": "xero-desktop",
-  "version": "0.1.39",
+  "version": "0.1.40",
   "identifier": "com.hyperpush.xero",
   "build": {
     "beforeDevCommand": "pnpm dev",

--- a/cloud/src/lib/relay/relay-client.test.ts
+++ b/cloud/src/lib/relay/relay-client.test.ts
@@ -247,8 +247,44 @@ describe("pushInboundCommand", () => {
 					sourceHeight: 100,
 				},
 			});
+			const staleDragMove = sendComputerUseManualInput(channel, {
+				computerId: "desktop-1",
+				sessionId: "session-1",
+				deviceId: "web-1",
+				manualControlId: "manual-web-1",
+				streamToken: "stream-token-1",
+				input: {
+					action: "mouse_drag_move",
+					x: 30,
+					y: 30,
+					sourceWidth: 100,
+					sourceHeight: 100,
+					button: "left",
+				},
+			});
+			void sendComputerUseManualInput(channel, {
+				computerId: "desktop-1",
+				sessionId: "session-1",
+				deviceId: "web-1",
+				manualControlId: "manual-web-1",
+				streamToken: "stream-token-1",
+				input: {
+					action: "mouse_drag_move",
+					x: 40,
+					y: 40,
+					sourceWidth: 100,
+					sourceHeight: 100,
+					button: "left",
+				},
+			});
 
 			await expect(staleMove).resolves.toEqual(
+				expect.objectContaining({
+					outcome: "stale",
+					reason: "coalesced",
+				}),
+			);
+			await expect(staleDragMove).resolves.toEqual(
 				expect.objectContaining({
 					outcome: "stale",
 					reason: "coalesced",

--- a/cloud/src/lib/relay/relay-client.ts
+++ b/cloud/src/lib/relay/relay-client.ts
@@ -136,6 +136,10 @@ const RELAY_COMMAND_MAX_IN_FLIGHT = 4;
 const RELAY_COMMAND_MAX_CRITICAL_QUEUE = 256;
 const RELAY_COMMAND_MAX_RELIABLE_QUEUE = 128;
 const RELAY_COMMAND_MAX_COALESCED_QUEUE = 64;
+const MANUAL_POINTER_INPUT_ACTIONS = new Set<ComputerUseManualInputAction>([
+	"mouse_move",
+	"mouse_drag_move",
+]);
 
 interface QueuedRelayCommand {
 	attempt: number;
@@ -418,12 +422,13 @@ function commandCoalesceKey(command: InboundCommand): string | null {
 	const payload = recordPayload(command.payload);
 	if (
 		command.kind === "computer_use_manual_control_input" &&
-		payload?.action === "mouse_move"
+		manualPointerInputAction(payload?.action)
 	) {
 		return [
 			command.kind,
 			command.session_id ?? "",
 			stringValue(payload.manualControlId),
+			stringValue(payload.action),
 		].join(":");
 	}
 	if (command.kind === "computer_use_stream_status") {
@@ -451,6 +456,15 @@ function recordPayload(value: unknown): Record<string, unknown> | null {
 
 function stringValue(value: unknown): string {
 	return typeof value === "string" ? value : "";
+}
+
+function manualPointerInputAction(
+	value: unknown,
+): value is "mouse_move" | "mouse_drag_move" {
+	return (
+		typeof value === "string" &&
+		MANUAL_POINTER_INPUT_ACTIONS.has(value as ComputerUseManualInputAction)
+	);
 }
 
 function commandResult(

--- a/cloud/src/routes/-desktop-click-ripple.test.tsx
+++ b/cloud/src/routes/-desktop-click-ripple.test.tsx
@@ -452,6 +452,35 @@ describe("ComputerUseDesktopViewport click feedback", () => {
 		expect(desktop.querySelector(".desktop-click-ripple")).toBeNull();
 	});
 
+	it("sends best-effort hover pointer moves during manual control", async () => {
+		const { desktop, image, push } = await renderManualDesktopViewport();
+		image.getBoundingClientRect = () => domRect(0, 0, 640, 360);
+		desktop.getBoundingClientRect = () => domRect(0, 0, 640, 360);
+		push.mockClear();
+
+		fireEvent.pointerMove(desktop, {
+			buttons: 0,
+			clientX: 320,
+			clientY: 180,
+			pointerId: 73,
+		});
+
+		expect(push).toHaveBeenCalledWith(
+			"frame",
+			expect.objectContaining({
+				kind: "computer_use_manual_control_input",
+				priority: "coalesced_best_effort",
+				payload: expect.objectContaining({
+					action: "mouse_move",
+					x: 640,
+					y: 360,
+					sourceWidth: 1280,
+					sourceHeight: 720,
+				}),
+			}),
+		);
+	});
+
 	it("shows a visible manual-control denial and keeps input disabled", async () => {
 		const { desktop, frameHandler, image, manualControlId, push, toolbar } =
 			await renderManualDesktopViewport({ grantManual: false });
@@ -853,12 +882,22 @@ describe("ComputerUseDesktopViewport click feedback", () => {
 			pointerId: 21,
 			pointerType: "touch",
 		});
-		fireEvent.pointerUp(desktop, {
-			clientX: 520,
+		fireEvent.pointerMove(desktop, {
+			clientX: 530,
 			clientY: 180,
 			pointerId: 22,
 			pointerType: "touch",
 		});
+		await waitFor(() => {
+			expect(mediaLayer.style.transform).toContain("scale(2)");
+		});
+		fireEvent.pointerUp(desktop, {
+			clientX: 530,
+			clientY: 180,
+			pointerId: 22,
+			pointerType: "touch",
+		});
+		expect(mediaLayer.style.transform).toContain("scale(2)");
 
 		image.getBoundingClientRect = () => domRect(-320, -180, 1280, 720);
 		push.mockClear();

--- a/cloud/src/routes/sessions.$computerId.$sessionId.tsx
+++ b/cloud/src/routes/sessions.$computerId.$sessionId.tsx
@@ -1188,7 +1188,7 @@ const MANUAL_KEYBOARD_FALLBACK_MS = 24;
 const MANUAL_KEYBOARD_TEXT_CHUNK_CHARS = 512;
 const MANUAL_KEYBOARD_TEXT_MAX_CHARS = 8_000;
 const MANUAL_KEYBOARD_COMPOSITION_DUPLICATE_MS = 80;
-const MANUAL_POINTER_MOVE_INTERVAL_MS = 33;
+const MANUAL_POINTER_MOVE_INTERVAL_MS = 50;
 const DESKTOP_MOBILE_ZOOM_MIN = 1;
 const DESKTOP_MOBILE_ZOOM_MAX = 4;
 const DESKTOP_POINTER_TAP_SLOP_PX = 8;
@@ -3940,6 +3940,14 @@ export function ComputerUseDesktopViewport({
 					beginMobilePinchGesture();
 				} else {
 					mobilePinchGestureRef.current = null;
+					const [remainingPointer] = mobileTouchPointersRef.current.values();
+					if (remainingPointer) {
+						remainingPointer.startClientX = remainingPointer.clientX;
+						remainingPointer.startClientY = remainingPointer.clientY;
+						remainingPointer.startTransform =
+							mobileViewportTransformRef.current;
+						remainingPointer.moved = true;
+					}
 				}
 				return;
 			}
@@ -4060,7 +4068,7 @@ export function ComputerUseDesktopViewport({
 				}
 				return;
 			}
-			if (!manualActive || event.buttons === 0) return;
+			if (!manualActive) return;
 			const now = Date.now();
 			if (
 				now - lastPointerMoveAtRef.current <
@@ -4068,9 +4076,10 @@ export function ComputerUseDesktopViewport({
 			) {
 				return;
 			}
-			lastPointerMoveAtRef.current = now;
 			const point = pointFromPointerEvent(event);
 			if (!point) return;
+			event.preventDefault();
+			lastPointerMoveAtRef.current = now;
 			sendManualInput({
 				action: "mouse_move",
 				x: point.x,

--- a/server/lib/xero_web/channels/remote_channel_rate_limit.ex
+++ b/server/lib/xero_web/channels/remote_channel_rate_limit.ex
@@ -74,8 +74,11 @@ defmodule XeroWeb.RemoteChannelRateLimit do
   defp computer_use_class("computer_use_manual_control_input", payload)
        when is_map(payload) do
     case payload do
-      %{"payload" => %{"action" => "mouse_move"}} -> "manual_pointer"
-      _ -> "manual_critical"
+      %{"payload" => %{"action" => action}} when action in ["mouse_move", "mouse_drag_move"] ->
+        "manual_pointer"
+
+      _ ->
+        "manual_critical"
     end
   end
 


### PR DESCRIPTION
## Summary
- Improve manual computer-control pointer responsiveness by coalescing hover/drag moves across cloud, relay, server rate limiting, and desktop bridge handling.
- Preserve mobile pinch zoom after manual-control gestures end.
- Bump desktop client and TUI versions to 0.1.40.

## Verification
- pnpm --dir cloud test src/lib/relay/relay-client.test.ts src/routes/-desktop-click-ripple.test.tsx: 2 files, 62 tests passed.
- pnpm --dir cloud exec biome check src/lib/relay/relay-client.ts src/lib/relay/relay-client.test.ts src/routes/-desktop-click-ripple.test.tsx 'src/routes/sessions.$computerId.$sessionId.tsx': passed.
- mix format --check-formatted lib/xero_web/channels/remote_channel_rate_limit.ex: passed.
- cargo metadata --manifest-path client/src-tauri/Cargo.toml --locked --no-deps --format-version 1: passed.
- cargo test --manifest-path client/src-tauri/Cargo.toml -p xero-remote-bridge bridge_outbound_queue_coalesces_successful_pointer_outcomes --lib: passed.
- cargo test --manifest-path client/src-tauri/Cargo.toml inbound_pointer_coalescing_keeps_latest_contiguous_move --lib: passed.
- cargo fmt --manifest-path client/src-tauri/Cargo.toml --check: passed.

## Known local verification gap
- mix test test/xero_web/channels/remote_channel_test.exs could not run locally because PostgreSQL on localhost:5432 refused the connection.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/hyperpush-org/codesmith/xero/pr/41"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1782836493&installation_id=136409793&pr_number=41&repository=hyperpush-org%2Fxero&return_to=https%3A%2F%2Fgithub.com%2Fhyperpush-org%2Fxero%2Fpull%2F41&signature=6d794e1fd36d615dc094cede390bd508dfe83f3ae12d46622d4fb7962c2c7c39"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->