### PR TITLE
Optimize runtime stream transcript aggregation

### DIFF
--- a/client/src/features/xero/use-xero-desktop-state/runtime-stream.ts
+++ b/client/src/features/xero/use-xero-desktop-state/runtime-stream.ts
@@ -336,6 +336,22 @@ function aggregateRuntimeTranscriptDeltas(
   }
 
   const aggregated: RuntimeStreamChannelPayload[] = []
+  let pendingTranscriptTextChunks: string[] | null = null
+  const flushPendingTranscriptText = () => {
+    if (!pendingTranscriptTextChunks) {
+      return
+    }
+
+    const previous = aggregated.at(-1)
+    if (previous && !isRuntimeStreamPatch(previous) && previous.item.kind === 'transcript') {
+      previous.item = {
+        ...previous.item,
+        text: pendingTranscriptTextChunks.join(''),
+      }
+    }
+    pendingTranscriptTextChunks = null
+  }
+
   for (const event of events) {
     const previous = aggregated.at(-1)
     if (
@@ -344,21 +360,24 @@ function aggregateRuntimeTranscriptDeltas(
       !isRuntimeStreamPatch(event) &&
       canAggregateRuntimeTranscriptDelta(previous, event)
     ) {
+      pendingTranscriptTextChunks ??= [previous.item.text ?? '']
+      pendingTranscriptTextChunks.push(event.item.text ?? '')
       previous.item = {
         ...previous.item,
-        text: `${previous.item.text ?? ''}${event.item.text ?? ''}`,
         updatedSequence: runtimeStreamPayloadUpdateSequence(event),
         createdAt: event.item.createdAt,
       }
       continue
     }
 
+    flushPendingTranscriptText()
     aggregated.push(
       !isRuntimeStreamPatch(event) && event.item.kind === 'transcript'
         ? cloneRuntimeStreamEventForAggregation(event)
         : event,
     )
   }
+  flushPendingTranscriptText()
   return aggregated
 }
 


### PR DESCRIPTION
## Summary

-

## Related Issues

Closes #

## Change Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Test/build tooling

## Testing

- [ ] `pnpm --dir client test`
- [ ] `pnpm --dir client lint`
- [ ] `cargo check --manifest-path client/src-tauri/Cargo.toml`
- [ ] Manual Tauri desktop verification
- [ ] Not applicable, with reason:

## UI Checklist

- [ ] Uses ShadCN/Radix UI patterns where possible
- [ ] Adds only user-facing UI, with no temporary debug or test UI
- [ ] Includes screenshots or recordings for visible UI changes

## Notes

-

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/hyperpush-org/codesmith/xero/pr/54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783799891&installation_id=136409793&pr_number=54&repository=hyperpush-org%2Fxero&return_to=https%3A%2F%2Fgithub.com%2Fhyperpush-org%2Fxero%2Fpull%2F54&signature=5e31a779ff81309fd1b45093469efdee1417d7a31426c02fe2772c3d5983633a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->