### PR TITLE
Coalesce runtime stream bursts before flush

### DIFF
--- a/client/src/features/xero/use-xero-desktop-state/runtime-stream.ts
+++ b/client/src/features/xero/use-xero-desktop-state/runtime-stream.ts
@@ -638,6 +638,22 @@ export function createRuntimeStreamEventBuffer({
   let cancelScheduledFlush: ScheduledFlushCancel | null = null
   let disposed = false
   let completionNotificationsEnabled = false
+  let pendingTranscriptTextChunks: string[] | null = null
+
+  const flushPendingTranscriptText = () => {
+    if (!pendingTranscriptTextChunks) {
+      return
+    }
+
+    const previous = pendingEvents.at(-1)
+    if (previous && !isRuntimeStreamPatch(previous) && previous.item.kind === 'transcript') {
+      previous.item = {
+        ...previous.item,
+        text: pendingTranscriptTextChunks.join(''),
+      }
+    }
+    pendingTranscriptTextChunks = null
+  }
 
   const cancelFlush = () => {
     if (!cancelScheduledFlush) {
@@ -659,6 +675,7 @@ export function createRuntimeStreamEventBuffer({
       return
     }
 
+    flushPendingTranscriptText()
     const events = pendingEvents.splice(0, pendingEvents.length)
     updateRuntimeStream(projectId, agentSessionId, (currentStream) => mergeRuntimeStreamEvents(currentStream, events))
     if (completionNotificationsEnabled) {
@@ -718,8 +735,33 @@ export function createRuntimeStreamEventBuffer({
 
       if (isRuntimeStreamPatch(payload)) {
         pendingEvents.length = 0
+        pendingTranscriptTextChunks = null
       }
-      pendingEvents.push(payload)
+
+      const previous = pendingEvents.at(-1)
+      if (
+        previous &&
+        !isRuntimeStreamPatch(previous) &&
+        !isRuntimeStreamPatch(payload) &&
+        canAggregateRuntimeTranscriptDelta(previous, payload)
+      ) {
+        pendingTranscriptTextChunks ??= [previous.item.text ?? '']
+        pendingTranscriptTextChunks.push(payload.item.text ?? '')
+        previous.item = {
+          ...previous.item,
+          updatedSequence: runtimeStreamPayloadUpdateSequence(payload),
+          createdAt: payload.item.createdAt,
+        }
+        schedule()
+        return
+      }
+
+      flushPendingTranscriptText()
+      pendingEvents.push(
+        !isRuntimeStreamPatch(payload) && payload.item.kind === 'transcript'
+          ? cloneRuntimeStreamEventForAggregation(payload)
+          : payload,
+      )
       if (isUrgentRuntimeStreamEvent(payload)) {
         flush()
         return
@@ -736,6 +778,7 @@ export function createRuntimeStreamEventBuffer({
       disposed = true
       cancelFlush()
       pendingEvents.length = 0
+      pendingTranscriptTextChunks = null
     },
   }
 }


### PR DESCRIPTION
## Summary

-

## Related Issues

Closes #

## Change Type

- [ ] Bug fix
- [ ] Feature
- [ ] Refactor
- [ ] Documentation
- [ ] Test/build tooling

## Testing

- [ ] `pnpm --dir client test`
- [ ] `pnpm --dir client lint`
- [ ] `cargo check --manifest-path client/src-tauri/Cargo.toml`
- [ ] Manual Tauri desktop verification
- [ ] Not applicable, with reason:

## UI Checklist

- [ ] Uses ShadCN/Radix UI patterns where possible
- [ ] Adds only user-facing UI, with no temporary debug or test UI
- [ ] Includes screenshots or recordings for visible UI changes

## Notes

-

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/hyperpush-org/codesmith/xero/pr/55"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1783809939&installation_id=136409793&pr_number=55&repository=hyperpush-org%2Fxero&return_to=https%3A%2F%2Fgithub.com%2Fhyperpush-org%2Fxero%2Fpull%2F55&signature=e586e5c98aa539cda8362953f9864c74bb123c68a731b924954ae96d54de266a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->