### PR TITLE
feat: add progress updates without reasoning traces

### DIFF
--- a/client/src-tauri/Cargo.toml
+++ b/client/src-tauri/Cargo.toml
@@ -160,6 +160,7 @@ windows = { version = "0.61.3", features = [
 [dev-dependencies]
 tempfile = "3"
 tauri = { version = "2", features = ["test"] }
+xero-agent-core = { path = "crates/xero-agent-core", features = ["test-support"] }
 
 [profile.dev]
 debug = "line-tables-only"

--- a/client/src-tauri/crates/xero-agent-core/Cargo.toml
+++ b/client/src-tauri/crates/xero-agent-core/Cargo.toml
@@ -7,6 +7,10 @@ description = "Reusable Xero agent harness facade and storage contracts"
 [lib]
 doctest = false
 
+[features]
+default = []
+test-support = []
+
 [dependencies]
 reqwest = { version = "0.12", default-features = false, features = ["blocking", "json", "rustls-tls"] }
 serde = { version = "1", features = ["derive"] }

--- a/client/src-tauri/crates/xero-agent-core/src/headless_runtime.rs
+++ b/client/src-tauri/crates/xero-agent-core/src/headless_runtime.rs
@@ -30,7 +30,7 @@ use crate::{
     ToolDispatchFailure, ToolDispatchOutcome, ToolDispatchSuccess, ToolEffectClass,
     ToolExecutionContext, ToolExecutionError, ToolGroupExecutionMode, ToolHandlerOutput,
     ToolMutability, ToolPolicy, ToolPolicyDecision, ToolRegistryV2, ToolResultTruncationContract,
-    ToolRollback, ToolSandboxRequirement, UserInputRequest,
+    ToolRollback, ToolSandboxRequirement, UserInputRequest, MUTATION_EXECUTION_SCOPE_ATTRIBUTE,
 };
 
 const DEFAULT_HEADLESS_PROVIDER_TIMEOUT_MS: u64 = 120_000;
@@ -1823,6 +1823,10 @@ impl HeadlessProductionToolRuntime {
                         "headless_production_provider_loop".into(),
                     ),
                     ("xero.dispatch.registry".into(), "tool_registry_v2".into()),
+                    (
+                        MUTATION_EXECUTION_SCOPE_ATTRIBUTE.into(),
+                        self.workspace_root.to_string_lossy().into_owned(),
+                    ),
                 ]),
             },
             cancellation_check: None,

--- a/client/src-tauri/crates/xero-agent-core/src/tool_registry.rs
+++ b/client/src-tauri/crates/xero-agent-core/src/tool_registry.rs
@@ -31,6 +31,7 @@ const MUTATION_TERMINATION_GRACE: Duration = Duration::from_millis(25);
 const MUTATION_SUPERVISOR_POLL_INTERVAL: Duration = Duration::from_millis(5);
 const MAX_MUTATION_WORKER_MESSAGE_BYTES: usize = 32 * 1024 * 1024;
 pub const TOOL_EXTENSION_MANIFEST_CONTRACT_VERSION: u32 = 1;
+pub const MUTATION_EXECUTION_SCOPE_ATTRIBUTE: &str = "xero.mutation.scope";
 
 static MUTATION_BOUNDARY_CHILD_ACTIVE: AtomicBool = AtomicBool::new(false);
 
@@ -1677,7 +1678,16 @@ struct MutationQuarantine {
 
 #[derive(Default)]
 struct MutationExecutionState {
-    quarantine: Option<MutationQuarantine>,
+    quarantines: BTreeMap<String, MutationQuarantine>,
+}
+
+fn mutation_execution_scope(context: &ToolExecutionContext) -> String {
+    context
+        .telemetry_attributes
+        .get(MUTATION_EXECUTION_SCOPE_ATTRIBUTE)
+        .filter(|scope| !scope.trim().is_empty())
+        .map(|scope| format!("{}\u{1f}{scope}", context.project_id))
+        .unwrap_or_else(|| context.project_id.clone())
 }
 
 fn global_mutation_execution_state() -> Arc<Mutex<MutationExecutionState>> {
@@ -1691,6 +1701,14 @@ pub struct ToolRegistryV2 {
     handlers: BTreeMap<String, Arc<dyn ToolHandler>>,
     read_only_worker_supervisor: Arc<ReadOnlyWorkerSupervisor>,
     mutation_execution_state: Arc<Mutex<MutationExecutionState>>,
+    mutation_boundary: MutationBoundary,
+}
+
+#[derive(Clone, Copy)]
+enum MutationBoundary {
+    TerminableProcess,
+    #[cfg(any(test, feature = "test-support"))]
+    CooperativeTestHarness,
 }
 
 impl Default for ToolRegistryV2 {
@@ -1705,7 +1723,15 @@ impl ToolRegistryV2 {
             handlers: BTreeMap::new(),
             read_only_worker_supervisor: global_read_only_worker_supervisor(),
             mutation_execution_state: global_mutation_execution_state(),
+            mutation_boundary: MutationBoundary::TerminableProcess,
         }
+    }
+
+    #[cfg(any(test, feature = "test-support"))]
+    #[doc(hidden)]
+    pub fn with_cooperative_mutation_boundary_for_tests(mut self) -> Self {
+        self.mutation_boundary = MutationBoundary::CooperativeTestHarness;
+        self
     }
 
     #[cfg(test)]
@@ -1714,6 +1740,7 @@ impl ToolRegistryV2 {
             handlers: BTreeMap::new(),
             read_only_worker_supervisor: Arc::new(ReadOnlyWorkerSupervisor::new(max_workers)),
             mutation_execution_state: Arc::new(Mutex::new(MutationExecutionState::default())),
+            mutation_boundary: MutationBoundary::TerminableProcess,
         }
     }
 
@@ -1955,11 +1982,21 @@ impl ToolRegistryV2 {
         match self.prepare_call(&call, tracker, config, deadline, cancellation_token) {
             Ok(prepared) => {
                 let mut outcome = if prepared.descriptor.mutability == ToolMutability::Mutating {
-                    let mut mutation_state = self
-                        .mutation_execution_state
-                        .lock()
-                        .unwrap_or_else(|poisoned| poisoned.into_inner());
-                    execute_mutating_call_in_boundary(prepared, config, &mut mutation_state)
+                    match self.mutation_boundary {
+                        MutationBoundary::TerminableProcess => {
+                            let mut mutation_state = self
+                                .mutation_execution_state
+                                .lock()
+                                .unwrap_or_else(|poisoned| poisoned.into_inner());
+                            execute_mutating_call_in_boundary(prepared, config, &mut mutation_state)
+                        }
+                        #[cfg(any(test, feature = "test-support"))]
+                        MutationBoundary::CooperativeTestHarness => execute_prepared_call(
+                            prepared,
+                            &config.context,
+                            config.rollback.as_deref(),
+                        ),
+                    }
                 } else {
                     execute_prepared_call(prepared, &config.context, config.rollback.as_deref())
                 };
@@ -2278,12 +2315,13 @@ fn execute_mutating_call_in_boundary(
     config: &ToolDispatchConfig,
     mutation_state: &mut MutationExecutionState,
 ) -> ToolDispatchOutcome {
+    let mutation_scope = mutation_execution_scope(&config.context);
     let pending = PendingMutationToolCall::from_prepared(&prepared);
     let deadline = prepared
         .deadline
         .unwrap_or_else(|| group_deadline(&config.budget));
     let mut audit_events = Vec::new();
-    if let Some(quarantine) = mutation_state.quarantine.take() {
+    if let Some(quarantine) = mutation_state.quarantines.remove(&mutation_scope) {
         match recover_mutation_quarantine(&quarantine, config) {
             Ok(_) => audit_events.push("mutation_quarantine_recovered".to_string()),
             Err(rollback_error) => {
@@ -2292,7 +2330,9 @@ fn execute_mutating_call_in_boundary(
                     ..quarantine
                 };
                 let failure = pending.quarantined_failure(&quarantine);
-                mutation_state.quarantine = Some(quarantine);
+                mutation_state
+                    .quarantines
+                    .insert(mutation_scope.clone(), quarantine);
                 let mut outcome = ToolDispatchOutcome::Failed(failure);
                 attach_mutation_boundary_metadata(
                     &mut outcome,
@@ -2431,10 +2471,13 @@ fn execute_mutating_call_in_boundary(
                     }
                     Err(rollback_error) => {
                         failure.rollback_error = Some(rollback_error.clone());
-                        mutation_state.quarantine = Some(MutationQuarantine {
-                            rollback_error,
-                            ..quarantine
-                        });
+                        mutation_state.quarantines.insert(
+                            mutation_scope.clone(),
+                            MutationQuarantine {
+                                rollback_error,
+                                ..quarantine
+                            },
+                        );
                         audit_events.push("mutation_quarantined".to_string());
                     }
                 }
@@ -2446,7 +2489,7 @@ fn execute_mutating_call_in_boundary(
             Some(&affected_paths),
             phase,
             &audit_events,
-            mutation_state.quarantine.is_some(),
+            mutation_state.quarantines.contains_key(&mutation_scope),
         );
         return outcome;
     }
@@ -2476,10 +2519,13 @@ fn execute_mutating_call_in_boundary(
         }
         Err(rollback_error) => {
             failure.rollback_error = Some(rollback_error.clone());
-            mutation_state.quarantine = Some(MutationQuarantine {
-                rollback_error,
-                ..quarantine
-            });
+            mutation_state.quarantines.insert(
+                mutation_scope.clone(),
+                MutationQuarantine {
+                    rollback_error,
+                    ..quarantine
+                },
+            );
             audit_events.push("mutation_quarantined".to_string());
         }
     }
@@ -2495,7 +2541,7 @@ fn execute_mutating_call_in_boundary(
         Some(&affected_paths),
         phase,
         &audit_events,
-        mutation_state.quarantine.is_some(),
+        mutation_state.quarantines.contains_key(&mutation_scope),
     );
     outcome
 }
@@ -5315,7 +5361,7 @@ mod tests {
 
     #[cfg(unix)]
     #[test]
-    fn rollback_hang_is_terminated_and_quarantines_later_mutations() {
+    fn rollback_hang_quarantines_only_later_mutations_in_the_same_scope() {
         let recovery_marker = std::env::temp_dir().join(format!(
             "xero-rollback-recovery-ready-{}",
             std::process::id()
@@ -5347,9 +5393,18 @@ mod tests {
             max_mutation_cleanup_ms: 20,
             ..ToolBudget::default()
         };
+        let mutation_context = |scope: &str| ToolExecutionContext {
+            project_id: "shared-project".into(),
+            telemetry_attributes: BTreeMap::from([(
+                MUTATION_EXECUTION_SCOPE_ATTRIBUTE.into(),
+                scope.into(),
+            )]),
+            ..ToolExecutionContext::default()
+        };
         let hanging_config = ToolDispatchConfig {
             budget: budget.clone(),
             rollback: Some(hanging_rollback),
+            context: mutation_context("workspace-a"),
             ..ToolDispatchConfig::default()
         };
 
@@ -5363,6 +5418,14 @@ mod tests {
             &mut ToolBudgetTracker::new(budget.clone()),
             &hanging_config,
         );
+        let other_scope = registry.dispatch_call(
+            call("call-other-scope", "later_mutation", "src/later.rs"),
+            &mut ToolBudgetTracker::new(budget.clone()),
+            &ToolDispatchConfig {
+                context: mutation_context("workspace-b"),
+                ..hanging_config.clone()
+            },
+        );
         std::fs::write(&recovery_marker, "ready").expect("mark rollback recovery ready");
         let recovered = registry.dispatch_call(
             call("call-recovered", "later_mutation", "src/later.rs"),
@@ -5370,6 +5433,7 @@ mod tests {
             &ToolDispatchConfig {
                 budget,
                 rollback: Some(Arc::new(RecoverWithoutCheckpointRollback)),
+                context: mutation_context("workspace-a"),
                 ..ToolDispatchConfig::default()
             },
         );
@@ -5387,6 +5451,7 @@ mod tests {
             blocked.failure().expect("quarantine failure").error.code,
             "agent_tool_mutation_quarantined"
         );
+        assert!(other_scope.is_success());
         assert!(recovered.is_success());
     }
 

--- a/client/src-tauri/src/runtime/agent_core/context_package.rs
+++ b/client/src-tauri/src/runtime/agent_core/context_package.rs
@@ -50,6 +50,28 @@ fn required_attachment_input_modality(attachment: &MessageAttachment) -> Option<
     }
 }
 
+fn should_request_user_facing_progress_updates(
+    provider_preflight: &xero_agent_core::ProviderPreflightSnapshot,
+    thinking_effort: Option<&ProviderModelThinkingEffortDto>,
+) -> bool {
+    let thinking_enabled = thinking_effort
+        .is_some_and(|effort| !matches!(effort, ProviderModelThinkingEffortDto::None));
+    let reasoning = &provider_preflight.capabilities.capabilities.reasoning;
+    let model_supports_thinking = matches!(reasoning.status.as_str(), "supported" | "probed");
+    let route_exposes_reasoning_summary = matches!(
+        reasoning.summary_support.as_str(),
+        "auto_summary_supported"
+            | "reasoning_summary_delta_supported"
+            | "reasoning_content_replay_required"
+            | "provider_default"
+    );
+
+    !(thinking_enabled
+        && model_supports_thinking
+        && route_exposes_reasoning_summary
+        && !provider_preflight.stale)
+}
+
 #[cfg(test)]
 pub(crate) fn assemble_provider_context_package(
     input: ProviderContextPackageInput<'_>,
@@ -121,10 +143,35 @@ pub(crate) fn assemble_provider_context_package_with_prompt_budget(
     )?;
     let active_coordination_summary =
         active_coordination_prompt_summary(&active_coordination_context);
+    let mut required_provider_features =
+        xero_agent_core::ProviderPreflightRequiredFeatures::owned_agent_text_turn();
+    required_provider_features.set_attachment_input_modalities(input.messages.iter().flat_map(
+        |message| {
+            match message {
+                ProviderMessage::User { attachments, .. } => attachments
+                    .iter()
+                    .filter_map(required_attachment_input_modality)
+                    .collect::<Vec<_>>(),
+                ProviderMessage::Developer { .. }
+                | ProviderMessage::Assistant { .. }
+                | ProviderMessage::AssistantContext { .. }
+                | ProviderMessage::Tool { .. } => Vec::new(),
+            }
+        },
+    ));
+    let provider_preflight = input.provider_preflight.cloned().unwrap_or_else(|| {
+        crate::provider_preflight::static_provider_preflight_snapshot(
+            input.provider_id,
+            input.model_id,
+            required_provider_features,
+        )
+    });
+    let user_facing_progress_updates =
+        should_request_user_facing_progress_updates(&provider_preflight, thinking_effort);
     let turn_budget = resolve_provider_turn_budget(
         input.provider_id,
         input.model_id,
-        input.provider_preflight,
+        Some(&provider_preflight),
         thinking_effort,
     )?;
     let context_limit = turn_budget.context_limit;
@@ -172,6 +219,7 @@ pub(crate) fn assemble_provider_context_package_with_prompt_budget(
     .with_relevant_paths(relevant_paths.iter().map(String::as_str))
     .with_prompt_budget_tokens(prompt_budget_tokens)
     .with_runtime_metadata(runtime_metadata)
+    .with_user_facing_progress_updates(user_facing_progress_updates)
     .compile()?;
 
     let (included_contributors, prompt_fragments_json, prompt_redacted) =
@@ -430,29 +478,6 @@ pub(crate) fn assemble_provider_context_package_with_prompt_budget(
     } else {
         project_store::AgentContextRedactionState::Clean
     };
-    let mut required_provider_features =
-        xero_agent_core::ProviderPreflightRequiredFeatures::owned_agent_text_turn();
-    required_provider_features.set_attachment_input_modalities(input.messages.iter().flat_map(
-        |message| {
-            match message {
-                ProviderMessage::User { attachments, .. } => attachments
-                    .iter()
-                    .filter_map(required_attachment_input_modality)
-                    .collect::<Vec<_>>(),
-                ProviderMessage::Developer { .. }
-                | ProviderMessage::Assistant { .. }
-                | ProviderMessage::AssistantContext { .. }
-                | ProviderMessage::Tool { .. } => Vec::new(),
-            }
-        },
-    ));
-    let provider_preflight = input.provider_preflight.cloned().unwrap_or_else(|| {
-        crate::provider_preflight::static_provider_preflight_snapshot(
-            input.provider_id,
-            input.model_id,
-            required_provider_features,
-        )
-    });
     let admitted_provider_preflight_hash = stable_provider_preflight_hash(&provider_preflight);
     let prompt_diff = prompt_diff_since_previous_manifest(
         input.repo_root,
@@ -3037,6 +3062,47 @@ mod tests {
     };
 
     #[test]
+    fn progress_contract_uses_effective_thinking_and_route_capabilities() {
+        let mut preflight = crate::provider_preflight::static_provider_preflight_snapshot(
+            OPENAI_CODEX_PROVIDER_ID,
+            OPENAI_CODEX_PROVIDER_ID,
+            xero_agent_core::ProviderPreflightRequiredFeatures::owned_agent_text_turn(),
+        );
+        preflight.provider_id = "provider-without-name-rules".into();
+        preflight.model_id = "model-without-name-rules".into();
+        preflight.stale = false;
+        let reasoning = &mut preflight.capabilities.capabilities.reasoning;
+        reasoning.status = "supported".into();
+        reasoning.summary_support = "auto_summary_supported".into();
+
+        assert!(should_request_user_facing_progress_updates(
+            &preflight, None
+        ));
+        assert!(should_request_user_facing_progress_updates(
+            &preflight,
+            Some(&ProviderModelThinkingEffortDto::None)
+        ));
+        assert!(!should_request_user_facing_progress_updates(
+            &preflight,
+            Some(&ProviderModelThinkingEffortDto::High)
+        ));
+
+        preflight.capabilities.capabilities.reasoning.status = "unavailable".into();
+        assert!(should_request_user_facing_progress_updates(
+            &preflight,
+            Some(&ProviderModelThinkingEffortDto::High)
+        ));
+
+        let reasoning = &mut preflight.capabilities.capabilities.reasoning;
+        reasoning.status = "supported".into();
+        reasoning.summary_support = "unavailable".into();
+        assert!(should_request_user_facing_progress_updates(
+            &preflight,
+            Some(&ProviderModelThinkingEffortDto::High)
+        ));
+    }
+
+    #[test]
     fn child_context_manifest_metadata_traces_parent_inheritance_reasons() {
         let snapshot = json!({
             "scope": "runtime_child",
@@ -3198,6 +3264,79 @@ mod tests {
         assert_eq!(metadata.timestamp_utc, "2026-06-01T09:30:00Z");
         assert_eq!(metadata.date_utc, "2026-06-01");
         assert_ne!(metadata.date_utc, "2026-05-01");
+    }
+
+    #[test]
+    fn provider_context_recomputes_progress_contract_for_each_turn_capability_snapshot() {
+        let root = tempfile::tempdir().expect("temp dir");
+        let (project_id, repo_root) = seed_project(&root);
+        seed_run(&repo_root, &project_id);
+        let messages = vec![ProviderMessage::User {
+            content: "Inspect and verify the runtime.".into(),
+            attachments: Vec::new(),
+        }];
+        let mut preflight = crate::provider_preflight::static_provider_preflight_snapshot(
+            OPENAI_CODEX_PROVIDER_ID,
+            OPENAI_CODEX_PROVIDER_ID,
+            xero_agent_core::ProviderPreflightRequiredFeatures::owned_agent_text_turn(),
+        );
+        preflight.stale = false;
+        let reasoning = &mut preflight.capabilities.capabilities.reasoning;
+        reasoning.status = "supported".into();
+        reasoning.summary_support = "auto_summary_supported".into();
+        let compile =
+            |preflight: &xero_agent_core::ProviderPreflightSnapshot,
+             thinking_effort: Option<&ProviderModelThinkingEffortDto>| {
+                assemble_provider_context_package_with_prompt_budget(
+                    ProviderContextPackageInput {
+                        repo_root: &repo_root,
+                        project_id: &project_id,
+                        agent_session_id: project_store::DEFAULT_AGENT_SESSION_ID,
+                        run_id: "run-context-package",
+                        runtime_agent_id: RuntimeAgentIdDto::Engineer,
+                        agent_definition_id: "engineer",
+                        agent_definition_version: project_store::BUILTIN_AGENT_DEFINITION_VERSION,
+                        agent_definition_snapshot: None,
+                        provider_id: OPENAI_CODEX_PROVIDER_ID,
+                        model_id: OPENAI_CODEX_PROVIDER_ID,
+                        turn_index: 0,
+                        browser_control_preference: BrowserControlPreferenceDto::Default,
+                        tool_application_policy: ResolvedAgentToolApplicationStyleDto::default(),
+                        soul_settings: None,
+                        tools: &[],
+                        tool_exposure_plan: None,
+                        messages: &messages,
+                        owned_process_summary: None,
+                        provider_preflight: Some(preflight),
+                    },
+                    Vec::new(),
+                    Vec::new(),
+                    None,
+                    thinking_effort,
+                )
+                .expect("compile provider context")
+            };
+        let has_progress_contract = |package: &ProviderContextPackage| {
+            package
+                .compilation
+                .fragments
+                .iter()
+                .any(|fragment| fragment.id == "xero.user_facing_progress")
+        };
+
+        let visible_reasoning = compile(&preflight, Some(&ProviderModelThinkingEffortDto::High));
+        assert!(!has_progress_contract(&visible_reasoning));
+
+        let disabled_reasoning = compile(&preflight, Some(&ProviderModelThinkingEffortDto::None));
+        assert!(has_progress_contract(&disabled_reasoning));
+
+        preflight
+            .capabilities
+            .capabilities
+            .reasoning
+            .summary_support = "unavailable".into();
+        let unavailable_route = compile(&preflight, Some(&ProviderModelThinkingEffortDto::High));
+        assert!(has_progress_contract(&unavailable_route));
     }
 
     #[test]

--- a/client/src-tauri/src/runtime/agent_core/harness_contract.rs
+++ b/client/src-tauri/src/runtime/agent_core/harness_contract.rs
@@ -587,6 +587,14 @@ fn sample_skill_context() -> XeroSkillToolContextPayload {
 mod tests {
     use super::*;
 
+    fn platform_snapshot_hash(macos: &'static str, default: &'static str) -> &'static str {
+        if cfg!(target_os = "macos") {
+            macos
+        } else {
+            default
+        }
+    }
+
     #[test]
     fn contract_export_covers_every_enabled_tool_surface() {
         let root = tempfile::tempdir().expect("temp dir");
@@ -729,19 +737,31 @@ mod tests {
         let expected = vec![
             (
                 "generalist:base".to_string(),
-                "cdd7b1916e007bf1e1ca41f4db52aa617d4e4139abc6d251938900ab07c78150",
+                platform_snapshot_hash(
+                    "d8c4fa08bf440ed234b707b2f6e2fa48128e4902f4e5618f7606938dda61404a",
+                    "cdd7b1916e007bf1e1ca41f4db52aa617d4e4139abc6d251938900ab07c78150",
+                ),
             ),
             (
                 "generalist:custom_policy_skill_process_coordination".to_string(),
-                "5b23dbacaf99d1c6a5cafd6908fd7273420a72a5e51c85461c26264f71e9ee7d",
+                platform_snapshot_hash(
+                    "402cc105c8a1828ed5d231c7af8cf09486cb2ced1ebd43cef27d4695f777844e",
+                    "5b23dbacaf99d1c6a5cafd6908fd7273420a72a5e51c85461c26264f71e9ee7d",
+                ),
             ),
             (
                 "ask:base".to_string(),
-                "59cb50995b2411b1cdf794f5e22345e6d4b9bd506b37b1f87de3d36b1431a870",
+                platform_snapshot_hash(
+                    "f85fb0cf9d17f77702b22debedef7fc39965e056f94edabb8e615325f6048725",
+                    "59cb50995b2411b1cdf794f5e22345e6d4b9bd506b37b1f87de3d36b1431a870",
+                ),
             ),
             (
                 "ask:custom_policy_skill_process_coordination".to_string(),
-                "d0ff675140aee4a6f3a1a3048c42b2394ffd4ec37fba2360379d830b24c274bb",
+                platform_snapshot_hash(
+                    "aa84a3099439260172f4bc1596c796b4a75b6e1b65761f31b7fcd48888ec55f9",
+                    "d0ff675140aee4a6f3a1a3048c42b2394ffd4ec37fba2360379d830b24c274bb",
+                ),
             ),
             (
                 "computer_use:base".to_string(),
@@ -749,31 +769,52 @@ mod tests {
             ),
             (
                 "computer_use:custom_policy_skill_process_coordination".to_string(),
-                "7ab9e920215ef8a3417fe2177ce3fc61f87d0d7d1793a84b6421ddcacd2b2284",
+                platform_snapshot_hash(
+                    "c97733c2f579d6615dacee24cebbbbe35d51ae4530c2ba7e30cef8e78455fdf9",
+                    "7ab9e920215ef8a3417fe2177ce3fc61f87d0d7d1793a84b6421ddcacd2b2284",
+                ),
             ),
             (
                 "plan:base".to_string(),
-                "1c7f6f0b37eca359abb945b604d87d755e729a98a7b37496d5f1afb4c329e006",
+                platform_snapshot_hash(
+                    "d8f2f8b939cefe13620caa235db3e95a34adf4945f548ba957b422c138424b4b",
+                    "1c7f6f0b37eca359abb945b604d87d755e729a98a7b37496d5f1afb4c329e006",
+                ),
             ),
             (
                 "plan:custom_policy_skill_process_coordination".to_string(),
-                "8a534329d99eea507d6d7fd660d17ed264ecab104c0467ceb141d8c48f80d9fa",
+                platform_snapshot_hash(
+                    "2847fdfab16d1afc01fc546a277acf74e58fc2e2a3fec54d1997d9cc1dbc0870",
+                    "8a534329d99eea507d6d7fd660d17ed264ecab104c0467ceb141d8c48f80d9fa",
+                ),
             ),
             (
                 "engineer:base".to_string(),
-                "07cb18ef973daa36f50df5f9fa4b6789dd83ebb351d9934503dcc9c18ba3ab0a",
+                platform_snapshot_hash(
+                    "1c7af471a2dc72793839185e3288c5f09239764408ca34fe9956730c2b0d734c",
+                    "07cb18ef973daa36f50df5f9fa4b6789dd83ebb351d9934503dcc9c18ba3ab0a",
+                ),
             ),
             (
                 "engineer:custom_policy_skill_process_coordination".to_string(),
-                "99f170dddee5857b63731a2d7723d6d2b1513ca7913b9c55cd6aa13b2e04263d",
+                platform_snapshot_hash(
+                    "26d1ab9b16ce85e1039f58b4900405e69f127000127c8f30d2153886bbb44090",
+                    "99f170dddee5857b63731a2d7723d6d2b1513ca7913b9c55cd6aa13b2e04263d",
+                ),
             ),
             (
                 "debug:base".to_string(),
-                "39171b55875d39ba35e315bb0b9b40f21f8ef3a35003664cbbead1bc5fb5bdb0",
+                platform_snapshot_hash(
+                    "9ee4751b20bfdc8baa302a66013786241bbd2e8e63b66c3ebc6695f863d8754d",
+                    "39171b55875d39ba35e315bb0b9b40f21f8ef3a35003664cbbead1bc5fb5bdb0",
+                ),
             ),
             (
                 "debug:custom_policy_skill_process_coordination".to_string(),
-                "a7a431263852e644627fe17bfb4e3406a8ceabbfc47a13f001c08ba45ce997b9",
+                platform_snapshot_hash(
+                    "ceb2ec95891f2b03679e0ec14038570ccec398e2c4333d689dc3ad90e4abcc35",
+                    "a7a431263852e644627fe17bfb4e3406a8ceabbfc47a13f001c08ba45ce997b9",
+                ),
             ),
             (
                 "crawl:base".to_string(),
@@ -781,7 +822,10 @@ mod tests {
             ),
             (
                 "crawl:custom_policy_skill_process_coordination".to_string(),
-                "d6dd01e993e0b26918a7171d3e3e36ff64d7119524a8d4ec439ddbf6bd1ef7f2",
+                platform_snapshot_hash(
+                    "dfbf028cbef8d3be1eb161bfa833ad2589cc682fe63a6443e2aeb20abf4f57fb",
+                    "d6dd01e993e0b26918a7171d3e3e36ff64d7119524a8d4ec439ddbf6bd1ef7f2",
+                ),
             ),
             (
                 "agent_create:base".to_string(),
@@ -789,7 +833,10 @@ mod tests {
             ),
             (
                 "agent_create:custom_policy_skill_process_coordination".to_string(),
-                "f8f708e512a60923ac2eb3d1b944e0b7ff04a0f7944e6a791cf8d3a77e58def8",
+                platform_snapshot_hash(
+                    "4f6a4a72f53cc36301ac11fc11846ffcb71231cbbc13a95604a389da1a3404f7",
+                    "f8f708e512a60923ac2eb3d1b944e0b7ff04a0f7944e6a791cf8d3a77e58def8",
+                ),
             ),
         ];
 
@@ -819,27 +866,45 @@ mod tests {
         let expected = vec![
             (
                 "generalist:builtin_full".to_string(),
-                "253ce7ad14915d6c6cb8a04ac81cce88e60bc5f2289529c7f9cc5a5c4250bd59",
+                platform_snapshot_hash(
+                    "9db7d7b2b96c144832ebe5ebb8ecb420f069f94ac8a550425df57c844a203695",
+                    "253ce7ad14915d6c6cb8a04ac81cce88e60bc5f2289529c7f9cc5a5c4250bd59",
+                ),
             ),
             (
                 "ask:builtin_full".to_string(),
-                "46a8937b85ee3a883a539384a4aa001359c1d6dab438886e4bb34063b9b767a3",
+                platform_snapshot_hash(
+                    "c93e6515140b2a0a0cac4d91da635a6fe9714e883d732c184fdd2b0f6b4bed68",
+                    "46a8937b85ee3a883a539384a4aa001359c1d6dab438886e4bb34063b9b767a3",
+                ),
             ),
             (
                 "computer_use:builtin_full".to_string(),
-                "8eb3b8f6748834ddb092165df03b2690ea8dc1706640e294a98078e80eb84c04",
+                platform_snapshot_hash(
+                    "5bc2879a7220bb82b63fb28c0d56152314d5c290308eefd6a638d526f37ffc6d",
+                    "8eb3b8f6748834ddb092165df03b2690ea8dc1706640e294a98078e80eb84c04",
+                ),
             ),
             (
                 "plan:builtin_full".to_string(),
-                "b3f7efe37a074e473c9d927a29aa016d852f6cb91cba78eb049cd1147a47114c",
+                platform_snapshot_hash(
+                    "c4ac952a8338531eae99a4287fc270449a7d0d95c871b27860563712a622bd73",
+                    "b3f7efe37a074e473c9d927a29aa016d852f6cb91cba78eb049cd1147a47114c",
+                ),
             ),
             (
                 "engineer:builtin_full".to_string(),
-                "253ce7ad14915d6c6cb8a04ac81cce88e60bc5f2289529c7f9cc5a5c4250bd59",
+                platform_snapshot_hash(
+                    "9db7d7b2b96c144832ebe5ebb8ecb420f069f94ac8a550425df57c844a203695",
+                    "253ce7ad14915d6c6cb8a04ac81cce88e60bc5f2289529c7f9cc5a5c4250bd59",
+                ),
             ),
             (
                 "debug:builtin_full".to_string(),
-                "253ce7ad14915d6c6cb8a04ac81cce88e60bc5f2289529c7f9cc5a5c4250bd59",
+                platform_snapshot_hash(
+                    "9db7d7b2b96c144832ebe5ebb8ecb420f069f94ac8a550425df57c844a203695",
+                    "253ce7ad14915d6c6cb8a04ac81cce88e60bc5f2289529c7f9cc5a5c4250bd59",
+                ),
             ),
             (
                 "crawl:builtin_full".to_string(),
@@ -851,11 +916,17 @@ mod tests {
             ),
             (
                 "engineer:custom_observe_only".to_string(),
-                "b62751c4bc98dc23e404b9fd8bce7401ba5f8ed10136f7bfc8668011a00f31b8",
+                platform_snapshot_hash(
+                    "ae2296be0564032232dc2e4f3cb60955f8022ba078f410a3e15cc1aba6ac3c68",
+                    "b62751c4bc98dc23e404b9fd8bce7401ba5f8ed10136f7bfc8668011a00f31b8",
+                ),
             ),
             (
                 "engineer:custom_engineering".to_string(),
-                "253ce7ad14915d6c6cb8a04ac81cce88e60bc5f2289529c7f9cc5a5c4250bd59",
+                platform_snapshot_hash(
+                    "9db7d7b2b96c144832ebe5ebb8ecb420f069f94ac8a550425df57c844a203695",
+                    "253ce7ad14915d6c6cb8a04ac81cce88e60bc5f2289529c7f9cc5a5c4250bd59",
+                ),
             ),
             (
                 "agent_create:custom_agent_builder".to_string(),

--- a/client/src-tauri/src/runtime/agent_core/provider_loop.rs
+++ b/client/src-tauri/src/runtime/agent_core/provider_loop.rs
@@ -5530,6 +5530,8 @@ struct ProviderStreamEventRecorder<'a> {
     candidate_id: String,
     turn_index: usize,
     accumulator: ProviderStreamDeltaAccumulator,
+    streamed_text: String,
+    committed_tool_turn_text_bytes: usize,
     terminal: bool,
 }
 
@@ -5548,6 +5550,8 @@ impl<'a> ProviderStreamEventRecorder<'a> {
             candidate_id,
             turn_index,
             accumulator: ProviderStreamDeltaAccumulator::default(),
+            streamed_text: String::new(),
+            committed_tool_turn_text_bytes: 0,
             terminal: false,
         };
         recorder.record_candidate_event(AssistantCandidateEventPayload::pending(
@@ -5567,18 +5571,28 @@ impl<'a> ProviderStreamEventRecorder<'a> {
         self.record_ready_events(ready)
     }
 
-    fn record_ready_events(&self, events: Vec<ProviderStreamEvent>) -> CommandResult<()> {
+    fn record_ready_events(&mut self, events: Vec<ProviderStreamEvent>) -> CommandResult<()> {
         for event in events {
             match event {
                 ProviderStreamEvent::MessageDelta(text) => {
                     if text.is_empty() {
                         continue;
                     }
+                    self.streamed_text.push_str(&text);
                     self.record_candidate_event(AssistantCandidateEventPayload::delta(
                         self.candidate_id.clone(),
                         self.turn_index,
                         text,
                     ))?;
+                }
+                event @ ProviderStreamEvent::ToolDelta { .. } => {
+                    self.commit_pending_tool_turn_text()?;
+                    record_provider_stream_event(
+                        self.repo_root,
+                        self.project_id,
+                        self.run_id,
+                        event,
+                    )?;
                 }
                 event => {
                     record_provider_stream_event(
@@ -5675,15 +5689,41 @@ impl<'a> ProviderStreamEventRecorder<'a> {
             reasoning_details.cloned(),
         ))?;
         self.terminal = true;
-        if commit_transcript && !text.is_empty() {
-            append_event(
-                self.repo_root,
-                self.project_id,
-                self.run_id,
-                AgentRunEventKind::MessageDelta,
-                json!({ "role": "assistant", "text": text }),
-            )?;
+        if commit_transcript {
+            self.commit_final_tool_turn_text(text)?;
         }
+        Ok(())
+    }
+
+    fn commit_pending_tool_turn_text(&mut self) -> CommandResult<()> {
+        if self.committed_tool_turn_text_bytes >= self.streamed_text.len() {
+            return Ok(());
+        }
+        let text = self.streamed_text[self.committed_tool_turn_text_bytes..].to_owned();
+        self.committed_tool_turn_text_bytes = self.streamed_text.len();
+        self.append_tool_turn_transcript_delta(&text)
+    }
+
+    fn commit_final_tool_turn_text(&self, text: &str) -> CommandResult<()> {
+        let committed_prefix = self
+            .streamed_text
+            .get(..self.committed_tool_turn_text_bytes)
+            .unwrap_or_default();
+        let remaining = text.strip_prefix(committed_prefix).unwrap_or(text);
+        self.append_tool_turn_transcript_delta(remaining)
+    }
+
+    fn append_tool_turn_transcript_delta(&self, text: &str) -> CommandResult<()> {
+        if text.trim().is_empty() {
+            return Ok(());
+        }
+        append_event(
+            self.repo_root,
+            self.project_id,
+            self.run_id,
+            AgentRunEventKind::MessageDelta,
+            json!({ "role": "assistant", "text": text }),
+        )?;
         Ok(())
     }
 
@@ -7657,13 +7697,137 @@ mod tests {
             .collect::<Vec<_>>();
         assert!(kinds.contains(&AgentRunEventKind::ReasoningSummary));
         assert!(kinds.contains(&AgentRunEventKind::ToolDelta));
-        assert_eq!(assistant_transcript_delta_payloads(&snapshot).len(), 1);
+        let transcript_deltas = assistant_transcript_delta_payloads(&snapshot);
+        assert_eq!(
+            transcript_deltas,
+            vec![json!({
+                "role": "assistant",
+                "text": "I will inspect."
+            })]
+        );
+        let progress_index = snapshot
+            .events
+            .iter()
+            .position(|event| {
+                event.event_kind == AgentRunEventKind::MessageDelta
+                    && serde_json::from_str::<JsonValue>(&event.payload_json)
+                        .ok()
+                        .and_then(|payload| payload["role"].as_str().map(str::to_owned))
+                        .as_deref()
+                        == Some("assistant")
+            })
+            .expect("assistant progress event");
+        let tool_index = snapshot
+            .events
+            .iter()
+            .position(|event| event.event_kind == AgentRunEventKind::ToolDelta)
+            .expect("tool delta event");
+        assert!(progress_index < tool_index);
         let candidates =
             reconstruct_assistant_candidates(&snapshot.events).expect("reconstruct candidate");
         assert_eq!(
             candidates[0].disposition,
             Some(AssistantCandidateDisposition::ToolCallTurn)
         );
+    }
+
+    #[test]
+    fn interleaved_tool_turn_progress_reloads_in_chronological_order() {
+        let _guard = project_state_test_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let run_id = "candidate-tool-turn-interleaved-progress";
+        let (_tempdir, repo_root, project_id, _controls, _tool_runtime, _messages) =
+            setup_test_agent_provider_loop(run_id);
+        let mut recorder = ProviderStreamEventRecorder::new(&repo_root, &project_id, run_id, 0)
+            .expect("start assistant candidate");
+        recorder
+            .record(ProviderStreamEvent::MessageDelta(
+                "I found the relevant module. ".into(),
+            ))
+            .expect("record first progress update");
+        recorder
+            .record(ProviderStreamEvent::ToolDelta {
+                tool_call_id: Some("call-1".into()),
+                tool_name: Some("read".into()),
+                arguments_delta: "{\"path\":\"src/lib.rs\"}".into(),
+            })
+            .expect("record first tool delta");
+        recorder
+            .record(ProviderStreamEvent::MessageDelta(
+                "The wiring is in place; I am verifying it now.".into(),
+            ))
+            .expect("record second progress update");
+        recorder
+            .record(ProviderStreamEvent::ToolDelta {
+                tool_call_id: Some("call-2".into()),
+                tool_name: Some("command".into()),
+                arguments_delta: "{\"command\":\"cargo test\"}".into(),
+            })
+            .expect("record second tool delta");
+        recorder
+            .finish_tool_turn(
+                "I found the relevant module. The wiring is in place; I am verifying it now.",
+                None,
+                None,
+            )
+            .expect("finish tool turn");
+
+        let snapshot = candidate_test_snapshot(&repo_root, &project_id, run_id);
+        assert_eq!(
+            assistant_transcript_delta_payloads(&snapshot),
+            vec![
+                json!({
+                    "role": "assistant",
+                    "text": "I found the relevant module. "
+                }),
+                json!({
+                    "role": "assistant",
+                    "text": "The wiring is in place; I am verifying it now."
+                }),
+            ]
+        );
+        let ordered = snapshot
+            .events
+            .iter()
+            .filter_map(|event| match event.event_kind {
+                AgentRunEventKind::MessageDelta => {
+                    let payload = serde_json::from_str::<JsonValue>(&event.payload_json).ok()?;
+                    (payload["role"] == "assistant").then_some("progress")
+                }
+                AgentRunEventKind::ToolDelta => Some("tool"),
+                _ => None,
+            })
+            .collect::<Vec<_>>();
+        assert_eq!(ordered, vec!["progress", "tool", "progress", "tool"]);
+    }
+
+    #[test]
+    fn empty_tool_turn_progress_is_not_persisted() {
+        let _guard = project_state_test_lock()
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+        let run_id = "candidate-tool-turn-empty-progress";
+        let (_tempdir, repo_root, project_id, _controls, _tool_runtime, _messages) =
+            setup_test_agent_provider_loop(run_id);
+        let mut recorder = ProviderStreamEventRecorder::new(&repo_root, &project_id, run_id, 0)
+            .expect("start assistant candidate");
+        recorder
+            .record(ProviderStreamEvent::MessageDelta(" \n\t".into()))
+            .expect("record empty progress");
+        recorder
+            .record(ProviderStreamEvent::ToolDelta {
+                tool_call_id: Some("call-empty".into()),
+                tool_name: Some("read".into()),
+                arguments_delta: "{}".into(),
+            })
+            .expect("record tool delta");
+        recorder
+            .finish_tool_turn(" \n\t", None, None)
+            .expect("finish tool turn");
+
+        let snapshot = candidate_test_snapshot(&repo_root, &project_id, run_id);
+        assert!(assistant_transcript_delta_payloads(&snapshot).is_empty());
     }
 
     #[test]

--- a/client/src-tauri/src/runtime/agent_core/tool_descriptors.rs
+++ b/client/src-tauri/src/runtime/agent_core/tool_descriptors.rs
@@ -143,6 +143,7 @@ pub(crate) struct PromptCompiler<'a> {
     relevant_paths: BTreeSet<String>,
     prompt_budget_tokens: Option<u64>,
     runtime_metadata: Option<RuntimeHostMetadata>,
+    user_facing_progress_updates: bool,
 }
 
 impl<'a> PromptCompiler<'a> {
@@ -172,6 +173,7 @@ impl<'a> PromptCompiler<'a> {
             relevant_paths: BTreeSet::new(),
             prompt_budget_tokens: None,
             runtime_metadata: None,
+            user_facing_progress_updates: false,
         }
     }
 
@@ -235,6 +237,11 @@ impl<'a> PromptCompiler<'a> {
         self
     }
 
+    pub(crate) fn with_user_facing_progress_updates(mut self, enabled: bool) -> Self {
+        self.user_facing_progress_updates = enabled;
+        self
+    }
+
     pub(crate) fn with_tool_application_policy(
         mut self,
         policy: ResolvedAgentToolApplicationStyleDto,
@@ -281,6 +288,18 @@ impl<'a> PromptCompiler<'a> {
             true,
             "authoritative_runtime_host_metadata",
         ));
+        if self.user_facing_progress_updates {
+            candidates.push(prompt_fragment_candidate(
+                "xero.user_facing_progress",
+                950,
+                "User-facing progress updates",
+                "xero-runtime:effective-reasoning-capabilities",
+                user_facing_progress_fragment(),
+                PromptFragmentBudgetPolicy::AlwaysInclude,
+                true,
+                "visible_reasoning_summaries_unavailable",
+            ));
+        }
         candidates.push(prompt_fragment_candidate(
             "xero.tool_policy",
             900,
@@ -487,6 +506,10 @@ fn render_prompt(fragments: &[PromptFragment]) -> String {
         prompt.push_str(&fragment.body);
     }
     prompt
+}
+
+fn user_facing_progress_fragment() -> String {
+    "## User-facing progress updates\nVisible reasoning summaries are unavailable for this turn. During long or multi-step work, emit brief progress updates as normal assistant text before tool calls at meaningful transitions: when a useful task-start orientation is needed, after a material finding or state change, before a longer verification phase, or when the plan meaningfully changes. State conclusions, changes, and the next action without revealing hidden chain-of-thought, private scratch work, tool-selection logic, secrets, or sensitive tool arguments. Do not label these updates as Reasoning or Thoughts. Do not emit an update for every tool call, and do not delay or block tool execution merely to manufacture an update. Short or simple work may finish without an intermediate update. Keep every progress update separate from the single final assistant response.".into()
 }
 
 fn prompt_fragment_with_policy(
@@ -11273,6 +11296,51 @@ mod tests {
             .expect("detect stale context");
 
         assert_eq!(stale, vec!["project:client/AGENTS.md"]);
+    }
+
+    #[test]
+    fn prompt_compiler_conditionally_adds_the_user_facing_progress_contract() {
+        let root = tempfile::tempdir().expect("temp dir");
+        let compile = |enabled| {
+            PromptCompiler::new(
+                root.path(),
+                None,
+                None,
+                RuntimeAgentIdDto::Ask,
+                BrowserControlPreferenceDto::Default,
+                &[],
+            )
+            .with_user_facing_progress_updates(enabled)
+            .compile()
+            .expect("compile prompt")
+        };
+
+        let enabled = compile(true);
+        let fragment = enabled
+            .fragments
+            .iter()
+            .find(|fragment| fragment.id == "xero.user_facing_progress")
+            .expect("progress contract fragment");
+        assert_eq!(
+            fragment.provenance,
+            "xero-runtime:effective-reasoning-capabilities"
+        );
+        assert_eq!(
+            fragment.budget_policy,
+            PromptFragmentBudgetPolicy::AlwaysInclude
+        );
+        assert!(fragment.body.contains("normal assistant text"));
+        assert!(fragment.body.contains("hidden chain-of-thought"));
+        assert!(fragment
+            .body
+            .contains("Do not emit an update for every tool call"));
+        assert!(fragment.body.contains("single final assistant response"));
+
+        let disabled = compile(false);
+        assert!(disabled
+            .fragments
+            .iter()
+            .all(|fragment| fragment.id != "xero.user_facing_progress"));
     }
 
     #[test]

--- a/client/src-tauri/src/runtime/agent_core/tool_dispatch.rs
+++ b/client/src-tauri/src/runtime/agent_core/tool_dispatch.rs
@@ -12,6 +12,7 @@ use xero_agent_core::{
     ToolErrorCategory, ToolExecutionContext, ToolExecutionControl, ToolExecutionError,
     ToolGroupExecutionMode, ToolHandler, ToolHandlerOutput, ToolPolicy, ToolPolicyDecision,
     ToolRegistryResult, ToolRegistryV2, ToolRollback, ToolSandbox, ToolSandboxResult,
+    MUTATION_EXECUTION_SCOPE_ATTRIBUTE,
 };
 
 #[derive(Debug, Clone, Default)]
@@ -435,6 +436,10 @@ fn dispatch_tool_batch_with_options(
                 telemetry_attributes: BTreeMap::from([
                     ("xero.dispatch.path".into(), "desktop_provider_loop".into()),
                     ("xero.dispatch.registry".into(), "tool_registry_v2".into()),
+                    (
+                        MUTATION_EXECUTION_SCOPE_ATTRIBUTE.into(),
+                        repo_root.to_string_lossy().into_owned(),
+                    ),
                 ]),
             },
             cancellation_check: Some(Arc::new(move || cancellation_runtime.is_cancelled())),
@@ -452,7 +457,7 @@ fn dispatch_tool_batch_with_options(
             .map(|tool_call| (tool_call.tool_call_id.clone(), tool_call.clone()))
             .collect::<BTreeMap<_, _>>();
         let report = registry_v2.dispatch_batch(&calls, &config);
-        persist_tool_batch_report(
+        let batch = persist_tool_batch_report(
             repo_root,
             project_id,
             run_id,
@@ -460,7 +465,13 @@ fn dispatch_tool_batch_with_options(
             &budget,
             &original_calls,
             &failure_log_context,
-        )
+        )?;
+        for result in &batch.results {
+            if result.ok {
+                tool_runtime.reconcile_isolated_tool_result(&result.tool_name, &result.output)?;
+            }
+        }
+        Ok(batch)
     })();
 
     restore_workspace_guard(&shared, workspace_guard)?;
@@ -471,7 +482,10 @@ fn build_tool_registry_v2(
     tool_registry: &ToolRegistry,
     shared: Arc<AutonomousToolHandlerShared>,
 ) -> CommandResult<ToolRegistryV2> {
-    let mut registry_v2 = ToolRegistryV2::new();
+    let registry_v2 = ToolRegistryV2::new();
+    #[cfg(test)]
+    let registry_v2 = registry_v2.with_cooperative_mutation_boundary_for_tests();
+    let mut registry_v2 = registry_v2;
     for descriptor in tool_registry.descriptors_v2() {
         if let Some(extension) = tool_registry.extension(&descriptor.name).cloned() {
             registry_v2

--- a/client/src-tauri/src/runtime/autonomous_tool_runtime/mod.rs
+++ b/client/src-tauri/src/runtime/autonomous_tool_runtime/mod.rs
@@ -416,7 +416,6 @@ const TOOL_ACCESS_REPOSITORY_RECON_TOOLS: &[&str] = &[
     AUTONOMOUS_TOOL_TOOL_ACCESS,
     AUTONOMOUS_TOOL_TOOL_SEARCH,
     AUTONOMOUS_TOOL_ACTION_REQUIRED,
-    AUTONOMOUS_TOOL_SUGGEST_ROUTING,
     AUTONOMOUS_TOOL_PROJECT_CONTEXT_SEARCH,
     AUTONOMOUS_TOOL_PROJECT_CONTEXT_GET,
     AUTONOMOUS_TOOL_WORKSPACE_INDEX,
@@ -6702,6 +6701,60 @@ impl AutonomousToolRuntime {
         Ok(policy
             .phase(&state.current_phase_id)
             .and_then(AutonomousAgentWorkflowPhase::registry_allowed_tools))
+    }
+
+    pub(crate) fn reconcile_isolated_tool_result(
+        &self,
+        tool_name: &str,
+        output: &JsonValue,
+    ) -> CommandResult<()> {
+        if !matches!(tool_name, AUTONOMOUS_TOOL_TODO | AUTONOMOUS_TOOL_SUBAGENT) {
+            return Ok(());
+        }
+        let result = serde_json::from_value::<AutonomousToolResult>(output.clone()).map_err(|error| {
+            CommandError::system_fault(
+                "agent_isolated_tool_state_decode_failed",
+                format!(
+                    "Xero could not decode isolated `{tool_name}` state for parent reconciliation: {error}"
+                ),
+            )
+        })?;
+        match result.output {
+            AutonomousToolOutput::Todo(output) => {
+                let mut todos = self.todo_items.lock().map_err(|_| {
+                    CommandError::system_fault(
+                        "autonomous_tool_todo_lock_failed",
+                        "Xero could not reconcile the owned-agent todo store after isolated execution.",
+                    )
+                })?;
+                *todos = output
+                    .items
+                    .into_iter()
+                    .map(|item| (item.id.clone(), item))
+                    .collect();
+            }
+            AutonomousToolOutput::Subagent(output) => {
+                let mut tasks = self.subagent_tasks.lock().map_err(|_| {
+                    CommandError::system_fault(
+                        "autonomous_tool_subagent_lock_failed",
+                        "Xero could not reconcile subagent state after isolated execution.",
+                    )
+                })?;
+                for task in output.active_tasks {
+                    tasks.insert(task.subagent_id.clone(), task);
+                }
+                tasks.insert(output.task.subagent_id.clone(), output.task);
+            }
+            _ => {
+                return Err(CommandError::system_fault(
+                    "agent_isolated_tool_state_kind_mismatch",
+                    format!(
+                        "Isolated `{tool_name}` execution returned a mismatched state payload."
+                    ),
+                ));
+            }
+        }
+        Ok(())
     }
 
     fn tool_available_by_runtime(&self, tool: &str) -> bool {


### PR DESCRIPTION
Closes #66

## Summary
- derive the progress-commentary contract from effective thinking support, the selected thinking setting, route summary visibility, and preflight freshness
- persist streamed assistant progress before interleaved tool rows, retain chronological reload ordering, keep the final response separate, and suppress whitespace-only noise
- reconcile parent todo/subagent state after isolated mutation execution, scope mutation quarantine per workspace, and keep the multithreaded desktop unit harness separate from the dedicated process-boundary tests
- preserve platform-specific harness contract snapshots and remove the disallowed Crawl routing tool from its exact allowlist

## Verification
- cargo test -p xero-desktop --lib -- --test-threads=1 (1703 passed)
- cargo test -p xero-agent-core --lib -- --test-threads=1 (124 passed)
- cargo test -p xero-desktop snapshot_hashes_freeze --lib -- --test-threads=1 (2 passed)
- cargo clippy -p xero-agent-core --lib --all-features -- -D warnings
- cargo clippy -p xero-desktop --lib -- -D warnings
- cargo fmt -p xero-agent-core -p xero-desktop

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/hyperpush-org/codesmith/xero/pr/68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1786275079&installation_id=136409793&pr_number=68&repository=hyperpush-org%2Fxero&return_to=https%3A%2F%2Fgithub.com%2Fhyperpush-org%2Fxero%2Fpull%2F68&signature=6764745b59fe9e1e6ec051b743d4eca567b4eea1adcc7be3dbedc16da4431a33"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->